### PR TITLE
Add support for SingleSignOnService/prepare_for_authentication with HTTP-POST binding

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -71,6 +71,10 @@ class VerifyError(SAMLError):
     pass
 
 
+class SignonError(SAMLError):
+    pass
+
+
 class LogoutError(SAMLError):
     pass
 

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -71,7 +71,7 @@ class VerifyError(SAMLError):
     pass
 
 
-class SignonError(SAMLError):
+class SignOnError(SAMLError):
     pass
 
 

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -619,10 +619,11 @@ class TestClientWithDummy():
     def test_do_authn(self):
         binding = BINDING_HTTP_REDIRECT
         response_binding = BINDING_HTTP_POST
-        sid, http_args = self.client.prepare_for_authenticate(
+        sid, auth_binding, http_args = self.client.prepare_for_authenticate(
             IDP, "http://www.example.com/relay_state",
             binding=binding, response_binding=response_binding)
 
+        assert binding == auth_binding
         assert isinstance(sid, basestring)
         assert len(http_args) == 4
         assert http_args["headers"][0][0] == "Location"
@@ -669,10 +670,12 @@ class TestClientWithDummy():
     def test_post_sso(self):
         binding = BINDING_HTTP_POST
         response_binding = BINDING_HTTP_POST
-        sid, http_args = self.client.prepare_for_authenticate(
+        sid, auth_binding, http_args = self.client.prepare_for_authenticate(
             "urn:mace:example.com:saml:roland:idp", relay_state="really",
             binding=binding, response_binding=response_binding)
         _dic = unpack_form(http_args["data"][3])
+
+        assert binding == auth_binding
 
         req = self.server.parse_authn_request(_dic["SAMLRequest"], binding)
         resp_args = self.server.response_args(req.message, [response_binding])

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -619,7 +619,26 @@ class TestClientWithDummy():
     def test_do_authn(self):
         binding = BINDING_HTTP_REDIRECT
         response_binding = BINDING_HTTP_POST
-        sid, auth_binding, http_args = self.client.prepare_for_authenticate(
+        sid, http_args = self.client.prepare_for_authenticate(
+            IDP, "http://www.example.com/relay_state",
+            binding=binding, response_binding=response_binding)
+
+        assert isinstance(sid, basestring)
+        assert len(http_args) == 4
+        assert http_args["headers"][0][0] == "Location"
+        assert http_args["data"] == []
+        redirect_url = http_args["headers"][0][1]
+        _, _, _, _, qs, _ = urlparse.urlparse(redirect_url)
+        qs_dict = urlparse.parse_qs(qs)
+        req = self.server.parse_authn_request(qs_dict["SAMLRequest"][0],
+                                              binding)
+        resp_args = self.server.response_args(req.message, [response_binding])
+        assert resp_args["binding"] == response_binding
+
+    def test_do_negotiated_authn(self):
+        binding = BINDING_HTTP_REDIRECT
+        response_binding = BINDING_HTTP_POST
+        sid, auth_binding, http_args = self.client.prepare_for_negotiated_authenticate(
             IDP, "http://www.example.com/relay_state",
             binding=binding, response_binding=response_binding)
 
@@ -670,7 +689,40 @@ class TestClientWithDummy():
     def test_post_sso(self):
         binding = BINDING_HTTP_POST
         response_binding = BINDING_HTTP_POST
-        sid, auth_binding, http_args = self.client.prepare_for_authenticate(
+        sid, http_args = self.client.prepare_for_authenticate(
+            "urn:mace:example.com:saml:roland:idp", relay_state="really",
+            binding=binding, response_binding=response_binding)
+        _dic = unpack_form(http_args["data"][3])
+
+        req = self.server.parse_authn_request(_dic["SAMLRequest"], binding)
+        resp_args = self.server.response_args(req.message, [response_binding])
+        assert resp_args["binding"] == response_binding
+
+        # Normally a response would now be sent back to the users web client
+        # Here I fake what the client will do
+        # create the form post
+
+        http_args["data"] = urllib.urlencode(_dic)
+        http_args["method"] = "POST"
+        http_args["dummy"] = _dic["SAMLRequest"]
+        http_args["headers"] = [('Content-type',
+                                 'application/x-www-form-urlencoded')]
+
+        response = self.client.send(**http_args)
+        print response.text
+        _dic = unpack_form(response.text[3], "SAMLResponse")
+        resp = self.client.parse_authn_request_response(_dic["SAMLResponse"],
+                                                        BINDING_HTTP_POST,
+                                                        {sid: "/"})
+        ac = resp.assertion.authn_statement[0].authn_context
+        assert ac.authenticating_authority[0].text == \
+            'http://www.example.com/login'
+        assert ac.authn_context_class_ref.text == INTERNETPROTOCOLPASSWORD
+
+    def test_negotiated_post_sso(self):
+        binding = BINDING_HTTP_POST
+        response_binding = BINDING_HTTP_POST
+        sid, auth_binding, http_args = self.client.prepare_for_negotiated_authenticate(
             "urn:mace:example.com:saml:roland:idp", relay_state="really",
             binding=binding, response_binding=response_binding)
         _dic = unpack_form(http_args["data"][3])


### PR DESCRIPTION
Warning, this changes the return type of `prepare_for_authentication` by including the chosen binding, and opens the door for supporting other SingleSignOnService bindings. If we want to maintain backwards compatibility though we could make a different function.