### PR TITLE
Fixed problem with metadata extensions

### DIFF
--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -469,7 +469,7 @@ def rec_factory(cls, **kwargs):
             except Exception:
                 continue
             else:
-                setattr(_inst, key, val)
+                setattr(_inst, _inst.c_attributes[key][0], val)
         elif key in _inst.c_child_order:
             for tag, _cls in _inst.c_children.values():
                 if tag == key:


### PR DESCRIPTION
With this small modification, I fixed I problem I was experiencing while trying to add RequestInitiator extension to a SP metadata.
The problem here is that the XML attributes are called Binding and Location while the python instance attributes are called binding and location respectively.

Se the instruction "elif key in _inst.c_attributes:" needs to have key with the capital letter while the setattr needs the lowercase name of the field. To be more generic I imagined it was better to retrieve the field name from the tuple associated to the field in c_attributes.

Now, if in my service config I specify:

      # Extensions for request initiator
      'extensions': {
        'reqinit': {
           'RequestInitiator': {
             'Binding': 'urn:oasis:names:tc:SAML:profiles:SSO:request-init',
             'Location': "%s%s" % (HOSTNAME, LOGIN_URL),
           },
        },
      },

it works without problems.

If the fix seems right, please accept it so that installations from PIP of pysaml could get the right version.
Thanks and cheers,
Andrea