### PR TITLE
mismatch between heading and example for authn_requests_signed.  the hea...

### DIFF
--- a/doc/howto/config.rst
+++ b/doc/howto/config.rst
@@ -357,7 +357,7 @@ Example::
 
     "service": {
         "sp": {
-            "authn_assertions_signed": "true",
+            "authn_requests_signed": "true",
         }
     }
 


### PR DESCRIPTION
...ding is correct.