### PR TITLE
some IdPs (for example OneLogin seem to exclude the trailing Z in the Is...

### DIFF
--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TIME_FORMAT_WITH_FRAGMENT = re.compile(
-    "^(\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2})(\.\d)*Z?$")
+    "^(\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2})(\.\d*)?Z?$")
 
 # ---------------------------------------------------------------------------
 # I'm sure this is implemented somewhere else can't find it now though, so I

--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -16,7 +16,7 @@ from datetime import datetime
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TIME_FORMAT_WITH_FRAGMENT = re.compile(
-    "^(\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2})\.\d*Z$")
+    "^(\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2})(\.\d)*Z?$")
 
 # ---------------------------------------------------------------------------
 # I'm sure this is implemented somewhere else can't find it now though, so I

--- a/tests/test_10_time_util.py
+++ b/tests/test_10_time_util.py
@@ -123,7 +123,9 @@ def test_str_to_time():
     #TODO: add something to show how this time was arrived at
     # do this as an external method in the 
     assert t == 947635200
-
+    # some IdPs omit the trailing Z, and SAML spec is unclear if it is actually required
+    t = calendar.timegm(str_to_time("2000-01-12T00:00:00"))
+    assert t == 947635200
 
 def test_instant():
     inst = str_to_time(instant())


### PR DESCRIPTION
...sueInstant.  str_to_time throws an exception in those cases.

updated the regex to handle the possible seconds in addition to the possible missing Z.  looked at the saml spec and it is unclear if the Z is required or just that the datetime is expected to be UTC.