### PR TITLE
Example SP: Fix failed auth redirect

### DIFF
--- a/example/sp-wsgi/sp.py
+++ b/example/sp-wsgi/sp.py
@@ -562,7 +562,7 @@ class SSO(object):
             logger.exception(exc)
             resp = ServiceError(
                 "Failed to construct the AuthnRequest: %s" % exc)
-            return resp(self.environ, self.start_response)
+            return resp
 
         # remember the request
         self.cache.outstanding_queries[_sid] = came_from


### PR DESCRIPTION
In case of an error during `SSO.redirect_to_auth` return the response unstarted.