### PR TITLE
Fixes is IDP example.

### DIFF
--- a/example/idp2/idp.py
+++ b/example/idp2/idp.py
@@ -132,7 +132,7 @@ class Service(object):
         else:
             # saml_msg may also contain Signature and SigAlg
             if "Signature" in saml_msg:
-                kwargs = {"signature": saml_msg["signature"],
+                kwargs = {"signature": saml_msg["Signature"],
                         "sigalg": saml_msg["SigAlg"]}
             else:
                 kwargs = {}

--- a/example/idp2/idp.py
+++ b/example/idp2/idp.py
@@ -292,7 +292,7 @@ class SSO(Service):
 
         return resp_args, _resp
 
-    def do(self, query, binding_in, relay_state="", encrypt_cert=None):
+    def do(self, query, binding_in, relay_state="", encrypt_cert=None, **kwargs):
         """
 
         :param query: The request
@@ -597,7 +597,7 @@ def not_found(environ, start_response):
 #    return subject, sp_entity_id
 
 class SLO(Service):
-    def do(self, request, binding, relay_state="", encrypt_cert=None):
+    def do(self, request, binding, relay_state="", encrypt_cert=None, **kwargs):
 
         logger.info("--- Single Log Out Service ---")
         try:


### PR DESCRIPTION
Some methods of classes derived from the `Service` class are called inside
parent (super) methods and the parameters are not always respected. In
occasions, they would be called with unexpected keyword arguments which
results in errors. Adding `**kwargs` to the methods' signatures makes the
IDP server less prone to dying because of these errors.