### PR TITLE
pymongo 3.0 no longer contains the deprecated Connection class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
 tests_require = [
     'mongodict',
     'pyasn1',
-    'pymongo',
+    'pymongo==3.0.1',
     'python-memcached == 1.51',
     'pytest',
     'mako',

--- a/src/saml2/mdbcache.py
+++ b/src/saml2/mdbcache.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import logging
+from pymongo.mongo_client import MongoClient
 
 __author__ = 'rolandh'
 
-from pymongo import Connection
 #import cjson
 import time
 from datetime import datetime
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 class Cache(object):
     def __init__(self, server=None, debug=0, db=None):
         if server:
-            connection = Connection(server)
+            connection = MongoClient(server)
         else:
-            connection = Connection()
+            connection = MongoClient()
 
         if db:
             self._db = connection[db]


### PR DESCRIPTION
Use MongoClient instead: https://jira.mongodb.org/browse/PYTHON-525?jql=project%20%3D%20PYTHON%20AND%20text%20~%20%22connection%20deprecated%22
