### PR TITLE
Require pycrypto 2.5+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'paste',
     'zope.interface',
     'repoze.who',
-    'pycrypto >= 2.2',  # 'Crypto'
+    'pycrypto >= 2.5',  # 'Crypto'
     'pytz',
     'pyOpenSSL',
     'python-dateutil',


### PR DESCRIPTION
It is required to use PKCS#1. With a lower version, it will fail to import `from Crypto.Signature import PKCS1_v1_5`.

- Changelog of pycrypto showing the introduction of PKCS#1 in 2.5: 
https://github.com/dlitz/pycrypto/blob/v2.6.1/ChangeLog#L108

- Where pysaml2 use it:
https://github.com/rohe/pysaml2/blob/2.4.0/src/saml2/sigver.py#L19
