### PR TITLE
Fix PEM file parsing

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -674,29 +674,26 @@ def read_cert_from_file(cert_file, cert_type):
         return ""
 
     if cert_type == "pem":
-        line = open(cert_file).read().replace("\r\n", "\n").split("\n")
+        lines = read_file(cert_file, 'rb').replace("\r\n", "\n").split("\n")
 
-        if line[0] == "-----BEGIN CERTIFICATE-----":
-            line = line[1:]
-        elif line[0] == "-----BEGIN PUBLIC KEY-----":
-            line = line[1:]
+        for pattern in (b"-----BEGIN CERTIFICATE-----", b"-----BEGIN PUBLIC KEY-----"): 
+            if pattern in lines:
+                lines = lines[lines.index(pattern):]
+                break
         else:
             raise CertificateError("Strange beginning of PEM file")
 
-        while line[-1] == "":
-            line = line[:-1]
-
-        if line[-1] == "-----END CERTIFICATE-----":
-            line = line[:-1]
-        elif line[-1] == "-----END PUBLIC KEY-----":
-            line = line[:-1]
+        for pattern in (b"-----END CERTIFICATE-----", b"-----END PUBLIC KEY-----"):
+            if pattern in lines:
+                lines = lines[:lines.index(pattern)]
+                break
         else:
             raise CertificateError("Strange end of PEM file")
-        return "".join(line)
+        return b"".join(lines)
 
     if cert_type in ["der", "cer", "crt"]:
-        data = read_file(cert_file)
-        return base64.b64encode(str(data))
+        data = read_file(cert_file, 'rb')
+        return base64.b64encode(data)
 
 
 class CryptoBackend():


### PR DESCRIPTION
PEM might contain headers. Always return bytes (untested but should fix python3 compatibility).

```py
Traceback (most recent call last):
    self.**sp = Saml2Client(config_file=self.configfile)
  File "/usr/lib/python2.7/dist-packages/saml2/client_base.py", line 94, in __init**
    Entity.**init**(self, "sp", config, config_file, virtual_organization)
  File "/usr/lib/python2.7/dist-packages/saml2/entity.py", line 119, in **init**
    self.config = config_factory(entity_type, config_file)
  File "/usr/lib/python2.7/dist-packages/saml2/config.py", line 538, in config_factory
    conf = SPConfig().load_file(filename)
  File "/usr/lib/python2.7/dist-packages/saml2/config.py", line 374, in load_file
    return self.load(copy.deepcopy(mod.CONFIG), metadata_construction)
  File "/usr/lib/python2.7/dist-packages/saml2/config.py", line 353, in load
    self.load_complex(cnf, metadata_construction=metadata_construction)
  File "/usr/lib/python2.7/dist-packages/saml2/config.py", line 293, in load_complex
    self.load_metadata(cnf["metadata"]))
  File "/usr/lib/python2.7/dist-packages/saml2/config.py", line 396, in load_metadata
    disable_ssl_certificate_validation=disable_validation)
  File "/usr/lib/python2.7/dist-packages/saml2/mdstore.py", line 757, in **init**
    self.security = security_context(config)
  File "/usr/lib/python2.7/dist-packages/saml2/sigver.py", line 1058, in security_context
    validate_certificate=conf.validate_certificate)
  File "/usr/lib/python2.7/dist-packages/saml2/sigver.py", line 1234, in **init**
    self.my_cert = read_cert_from_file(cert_file, cert_type)
  File "/usr/lib/python2.7/dist-packages/saml2/sigver.py", line 670, in read_cert_from_file
    raise CertificateError("Strange beginning of PEM file")
CertificateError: Strange beginning of PEM file
```
  