### PR TITLE
Fix before time_util function.

### DIFF
--- a/src/saml2/time_util.py
+++ b/src/saml2/time_util.py
@@ -280,7 +280,7 @@ def before(point):
     elif isinstance(point, int):
         point = time.gmtime(point)
 
-    return time.gmtime() < point
+    return time.gmtime() <= point
 
 
 def after(point):


### PR DESCRIPTION
```python
# a point is valid if it is now or sometime in the future, in other words, 
# if it is not before now
valid = before
```

Comment didn't match meaning of `before` function which caused problems for me.