### PR TITLE
Add import fallback for SimpleCookie

### DIFF
--- a/example/sp-wsgi/sp.py
+++ b/example/sp-wsgi/sp.py
@@ -4,7 +4,11 @@ import logging
 import re
 import argparse
 import os
-from future.backports.http.cookies import SimpleCookie
+try:
+    from future.backports.http.cookies import SimpleCookie
+except:
+    from Cookie import SimpleCookie
+import sixe
 import six
 
 from saml2.extension.pefim import SPCertEnc


### PR DESCRIPTION
`future.backports.http.cookies` doesn't exist in Python 2.7.3, this fixes that.