### PR TITLE
Allow logout to succeed if NotOnOrAfter expired.

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -207,7 +207,9 @@ class Saml2Client(Base):
                 destination = destinations(srvs)[0]
                 logger.info("destination to provider: %s", destination)
                 try:
-                    session_info = self.users.get_info_from(name_id, entity_id)
+                    session_info = self.users.get_info_from(name_id,
+                                                            entity_id,
+                                                            False)
                     session_indexes = [session_info['session_index']]
                 except KeyError:
                     session_indexes = None

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -45,8 +45,8 @@ class Population(object):
     def get_identity(self, name_id, entities=None, check_not_on_or_after=True):
         return self.cache.get_identity(name_id, entities, check_not_on_or_after)
 
-    def get_info_from(self, name_id, entity_id):
-        return self.cache.get(name_id, entity_id)
+    def get_info_from(self, name_id, entity_id, check_not_on_or_after=True):
+        return self.cache.get(name_id, entity_id, check_not_on_or_after)
 
     def subjects(self):
         """Returns the name id's for all the persons in the cache"""


### PR DESCRIPTION
A pull request I previously submitted inadvertently changed the behavior of `do_logout()` when the user's `session_info` was past the `not_on_or_after` timestamp.

The result was that `do_logout()` would throw a `ToOld` exception if either the `SessionNotOnOrAfter` or `NotOnOrAfter` on the Assertion had past.

I've done a bit of digging into the SAML 2.0. spec to find the following "fun" reading information:

> **2.5.1.2 Attributes `NotBefore` and `NotOnOrAfter`**
> 
> The `NotBefore` and `NotOnOrAfter` attributes specify **time limits on the validity of the assertion within the context of its profile(s) of use**. They do not guarantee that the statements in the assertion will be correct or accurate throughout the validity period.
> 
> The `NotBefore` attribute specifies the time instant at which the validity interval begins. The `NotOnOrAfter` attribute specifies the time instant at which the validity interval has ended.
> 
> If the value for either `NotBefore` or `NotOnOrAfter` is omitted, then it is considered unspecified. If the `NotBefore` attribute is unspecified (and if all other conditions that are supplied evaluate to Valid), then the assertion is Valid with respect to conditions at any time before the time instant specified by the `NotOnOrAfter` attribute. **If the `NotOnOrAfter` attribute is unspecified (and if all other conditions that are supplied evaluate to Valid), the assertion is Valid with respect to conditions from the time instant specified by the `NotBefore` attribute with no expiry**. If neither attribute is specified (and if any other conditions that are supplied evaluate to Valid), the assertion is Valid with respect to conditions at any time.
> 
> If both attributes are present, the value for `NotBefore` MUST be less than (earlier than) the value for `NotOnOrAfter`.

and...

> **`SessionNotOnOrAfter` [Optional]**
> 
> **Specifies a time instant at which the session between the principal identified by the subject and the SAML authority issuing this statement MUST be considered ended.** The time value is encoded in UTC, as described in Section 1.3.3. There is no required relationship between this attribute and a `NotOnOrAfter` condition attribute that may be present in the assertion.

I'm currently dealing with a situation where I'm getting a very short time period on the `NotOnOrAfter` and no `SessionNotOnOrAfter`. Looking on the Internet, there appears to be quite a bit of confusion as to exactly how these attributes should be used and/or related. I'm not sure that the usecase I'm dealing with is not valid and as such have opted to submit this pull request to "fix" `do_logout()` by allowing it behave the way it did previously in regards to expired sessions.