### PR TITLE
Ommit StatusMessage from Error response if empty

### DIFF
--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -236,20 +236,20 @@ def error_status_factory(info):
             msg = info.args[0]
         except IndexError:
             msg = "%s" % info
-        status = samlp.Status(
-            status_message=samlp.StatusMessage(text=msg),
-            status_code=samlp.StatusCode(
-                value=samlp.STATUS_RESPONDER,
-                status_code=samlp.StatusCode(
-                    value=exc_val)))
     else:
-        (errcode, text) = info
-        status = samlp.Status(
-            status_message=samlp.StatusMessage(text=text),
-            status_code=samlp.StatusCode(
-                value=samlp.STATUS_RESPONDER,
-                status_code=samlp.StatusCode(value=errcode)))
+        (exc_val, msg) = info
 
+    if msg:
+        status_msg = samlp.StatusMessage(text=msg)
+    else:
+        status_msg = None
+
+    status = samlp.Status(
+        status_message=status_msg,
+        status_code=samlp.StatusCode(
+            value=samlp.STATUS_RESPONDER,
+            status_code=samlp.StatusCode(
+                value=exc_val)))
     return status
 
 

--- a/tests/test_12_s_utils.py
+++ b/tests/test_12_s_utils.py
@@ -30,8 +30,15 @@ ERROR_STATUS_NO_HEADER = (
 'Value="urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" '
 '/></ns0:StatusCode><ns0:StatusMessage>Error resolving '
 'principal</ns0:StatusMessage></ns0:Status>')
-ERROR_STATUS = '%s%s' % (XML_HEADER, ERROR_STATUS_NO_HEADER)
 
+ERROR_STATUS_NO_HEADER_EMPTY = (
+'<ns0:Status xmlns:ns0="urn:oasis:names:tc:SAML:2.0:protocol"><ns0:StatusCode '
+'Value="urn:oasis:names:tc:SAML:2.0:status:Responder"><ns0:StatusCode '
+'Value="urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" '
+'/></ns0:StatusCode></ns0:Status>')
+
+ERROR_STATUS = '%s%s' % (XML_HEADER, ERROR_STATUS_NO_HEADER)
+ERROR_STATUS_EMPTY = '%s%s' % (XML_HEADER, ERROR_STATUS_NO_HEADER_EMPTY)
 
 def _eq(l1, l2):
     return set(l1) == set(l2)
@@ -87,6 +94,18 @@ def test_status_from_exception():
     status_text = "%s" % stat
     print(status_text)
     assert status_text in (ERROR_STATUS_NO_HEADER, ERROR_STATUS)
+
+
+def test_status_from_tuple():
+    stat = utils.error_status_factory((samlp.STATUS_UNKNOWN_PRINCIPAL, 'Error resolving principal'))
+    status_text = "%s" % stat
+    assert status_text == ERROR_STATUS
+
+
+def test_status_from_tuple_empty_message():
+    stat = utils.error_status_factory((samlp.STATUS_UNKNOWN_PRINCIPAL, None))
+    status_text = "%s" % stat
+    assert status_text == ERROR_STATUS_EMPTY
 
 
 def test_attribute_sn():


### PR DESCRIPTION
Although the resulting XML is valid, it fails validation by
java-opensaml2