### PR TITLE
Remove signature verification directly on origdoc

### DIFF
--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -1539,27 +1539,11 @@ class SecurityContext(object):
         for _, pem_file in certs:
             try:
                 last_pem_file = pem_file
-                if origdoc is not None:
-                    try:
-                        if self.verify_signature(origdoc, pem_file,
-                                                 node_name=node_name,
-                                                 node_id=item.id,
-                                                 id_attr=id_attr):
-                            verified = True
-                            break
-                    except Exception:
-                        if self.verify_signature(decoded_xml, pem_file,
-                                                 node_name=node_name,
-                                                 node_id=item.id,
-                                                 id_attr=id_attr):
-                            verified = True
-                            break
-                else:
-                    if self.verify_signature(decoded_xml, pem_file,
-                                             node_name=node_name,
-                                             node_id=item.id, id_attr=id_attr):
-                        verified = True
-                        break
+                if self.verify_signature(decoded_xml, pem_file,
+                                         node_name=node_name,
+                                         node_id=item.id, id_attr=id_attr):
+                    verified = True
+                    break
             except XmlsecError as exc:
                 logger.error("check_sig: %s", exc)
                 pass


### PR DESCRIPTION
The old logic always tried to verify signature directly on the (encrypted) origdoc
(original message), which often led to unnecessary xmlsec1 failures, accompanied
by an excessive and misleading logs. (Every Logout Request sent from IdP resulted in these errors).

The code such as this should never have to "guess" the content and act upon its
"best belief" as what the content actually is (or looks like). This "too smart"
behavior is commonly considered dangerous and has no place in security libraries.
