### PR TITLE
'AsTime' validator should be 'dateTime'

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -441,7 +441,7 @@ class SubjectConfirmationDataType_(SamlBase):
     c_attributes = SamlBase.c_attributes.copy()
     c_child_order = SamlBase.c_child_order[:]
     c_cardinality = SamlBase.c_cardinality.copy()
-    c_attributes['NotBefore'] = ('not_before', 'AsTime', False)
+    c_attributes['NotBefore'] = ('not_before', 'dateTime', False)
     c_attributes['NotOnOrAfter'] = ('not_on_or_after', 'dateTime', False)
     c_attributes['Recipient'] = ('recipient', 'anyURI', False)
     c_attributes['InResponseTo'] = ('in_response_to', 'NCName', False)

--- a/tests/test_02_saml.py
+++ b/tests/test_02_saml.py
@@ -851,6 +851,13 @@ class TestSubjectConfirmation:
         assert sc.subject_confirmation_data.in_response_to == "responseID"
         assert sc.subject_confirmation_data.address == "127.0.0.1"
 
+    def testVerify(self):
+        """Test SubjectConfirmation verify"""
+
+        sc = saml.subject_confirmation_from_string(
+            saml2_data.TEST_SUBJECT_CONFIRMATION)
+        assert sc.verify()
+
 
 class TestSubject:
     def setup_class(self):


### PR DESCRIPTION
We're failing to parse a SAMLResponse because it appears an attribute is using the wrong validator name:

```
Traceback (most recent call last):
  File "/site/cureatr-api/version/1454011124/api/controllers/saml.py", line 197, in acs
    saml2.BINDING_HTTP_POST)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/client_base.py", line 584, in parse_authn_request_response
    binding, **kwargs)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/entity.py", line 1131, in _parse_response
    response = response.loads(xmlstr, False, origxml=origxml)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/response.py", line 510, in loads
    self._loads(xmldata, decode, origxml)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/response.py", line 347, in _loads
    return self._postamble()
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/response.py", line 292, in _postamble
  valid_instance(self.response)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 438, in valid_instance
    _valid_instance(instance, val)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 348, in _valid_instance
    val.verify()
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/saml.py", line 1639, in verify
    return SamlBase.verify(self)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/__init__.py", line 887, in verify
    return valid_instance(self)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 440, in valid_instance
    _valid_instance(instance, value)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 348, in _valid_instance
    val.verify()
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/__init__.py", line 887, in verify
    return valid_instance(self)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 438, in valid_instance
    _valid_instance(instance,val)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 348, in _valid_instance
    val.verify()
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/__init__.py", line 887, in verify
    return valid_instance(self)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 440, in valid_instance
    _valid_instance(instance, value)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 348, in _valid_instance
    val.verify()
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/__init__.py", line 887, in verify
    return valid_instance(self)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 393, in valid_instance
    valid(typ, value)
  File "/virtualenv/local/lib/python2.7/site-packages/saml2/validate.py", line 343, in valid
    return VALIDATOR[typ](value)
KeyError: 'AsTime'
```