### PR TITLE
Use package 'Cryptodome' instead of 'Crypto'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'paste',
     'zope.interface',
     'repoze.who',
-    'pycryptodome',  # 'Crypto'
+    'pycryptodomex',
     'pytz',
     'pyOpenSSL',
     'python-dateutil',

--- a/src/saml2/aes.py
+++ b/src/saml2/aes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
-from Crypto import Random
-from Crypto.Cipher import AES
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
 from base64 import b64encode, b64decode
 
 __author__ = 'rolandh'

--- a/src/saml2/cert.py
+++ b/src/saml2/cert.py
@@ -8,7 +8,7 @@ import six
 from OpenSSL import crypto
 from os.path import join
 from os import remove
-from Crypto.Util import asn1
+from Cryptodome.Util import asn1
 
 class WrongInput(Exception):
     pass

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -4,7 +4,7 @@ from binascii import hexlify
 import copy
 import logging
 from hashlib import sha1
-from Crypto.PublicKey import RSA
+from Cryptodome.PublicKey import RSA
 import requests
 import six
 from saml2.metadata import ENDPOINTS

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -18,15 +18,15 @@ from time import mktime
 from binascii import hexlify
 import six
 
-from Crypto.PublicKey.RSA import importKey
-from Crypto.Signature import PKCS1_v1_5
-from Crypto.Util.asn1 import DerSequence
-from Crypto.PublicKey import RSA
-from Crypto.Hash import SHA
-from Crypto.Hash import SHA224
-from Crypto.Hash import SHA256
-from Crypto.Hash import SHA384
-from Crypto.Hash import SHA512
+from Cryptodome.PublicKey.RSA import importKey
+from Cryptodome.Signature import PKCS1_v1_5
+from Cryptodome.Util.asn1 import DerSequence
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Hash import SHA
+from Cryptodome.Hash import SHA224
+from Cryptodome.Hash import SHA256
+from Cryptodome.Hash import SHA384
+from Cryptodome.Hash import SHA512
 
 from tempfile import NamedTemporaryFile
 from subprocess import Popen


### PR DESCRIPTION
PyCryptodome - when installed via `pip installed pycryptodome` - is available under the `Crypto` package. In this way, applications that are based on the now-unmaintained PyCrypto can be left (almost) untouched. The caveat is that PyCrypto and PyCryptodome cannot be both present, as their code will clash. For pure applications or scripts, that is not a major problem as they will be typically deployed in a `virtualenv`.

However, pysaml2 is a library and one has little control over the application that will use it. It is therefore advisable to install PyCrytodome via `pip install pycryptodomex`.  The library and the code are exactly the same; they are just installed under the separate `Cryptodome` package.

_Disclaimer: I am the maintainer of PyCryptodome._