### PR TITLE
Wait until xmlsec program completes to avoid zombies

### DIFF
--- a/src/saml2/algsupport.py
+++ b/src/saml2/algsupport.py
@@ -39,6 +39,7 @@ def get_algorithm_support(xmlsec):
 
     p_out = pof.stdout.read().decode('utf-8')
     p_err = pof.stderr.read().decode('utf-8')
+    pof.wait()
 
     if not p_err:
         p = p_out.split('\n')

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -797,6 +797,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
         com_list = [self.xmlsec, "--version"]
         pof = Popen(com_list, stderr=PIPE, stdout=PIPE)
         content = pof.stdout.read().decode('ascii')
+        pof.wait()
         try:
             return content.split(" ")[1]
         except IndexError:
@@ -990,6 +991,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
 
         p_out = pof.stdout.read().decode('utf-8')
         p_err = pof.stderr.read().decode('utf-8')
+        pof.wait()
 
         if pof.returncode is not None and pof.returncode < 0:
             logger.error(LOG_LINE, p_out, p_err)


### PR DESCRIPTION
Popen was often used to execute the xmlsec program without
calling wait() on the process file handler, which resulted
in zombies being left for arbitrary time (depending on gc).

Adding the wait() call as implemented by this fix should not
cause any delays nor deadlocks since it is always run only
after the program finishes - after stdout and stderr are
read. It should thus not cause any regressions.

For more info about Popen causing zombies, please see:
http://stackoverflow.com/questions/2760652/how-to-kill-or-avoid-zombie-processes-with-subprocess-module
https://lbolla.info/blog/2014/01/23/die-zombie-die