### PR TITLE
Update population.py

### DIFF
--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -22,11 +22,13 @@ class Population(object):
 
         name_id = session_info["name_id"]
         # make friendly to (JSON) serialization
-        session_info['name_id'] = code(name_id)
+        #session_info['name_id'] = code(name_id)
+        name_id_coded = code(name_id)
         issuer = session_info["issuer"]
         del session_info["issuer"]
         self.cache.set(name_id, issuer, session_info,
                        session_info["not_on_or_after"])
+        session_info['name_id'] = name_id_coded
         return name_id
 
     def stale_sources_for_person(self, name_id, sources=None):


### PR DESCRIPTION
using pysaml2 with djangosaml2-knaperek==0.14.1 reults in an attribute error: 
str' object has no attribute 'name_qualifier'

The IdentityCache set method also calls code(name_id) but then it is already coded