### PR TITLE
Fix Name-ID caching type inconsistency

### DIFF
--- a/src/saml2/cache.py
+++ b/src/saml2/cache.py
@@ -113,6 +113,11 @@ class Cache(object):
         :param info: The session info, the assertion is part of this
         :param not_on_or_after: A time after which the assertion is not valid.
         """
+        info = dict(info)
+        if 'name_id' in info and not isinstance(info['name_id'], six.string_types):
+            # make friendly to (JSON) serialization
+            info['name_id'] = code(name_id)
+
         cni = code(name_id)
         if cni not in self._db:
             self._db[cni] = {}

--- a/src/saml2/population.py
+++ b/src/saml2/population.py
@@ -20,15 +20,11 @@ class Population(object):
         """If there already are information from this source in the cache
         this function will overwrite that information"""
 
+        session_info = dict(session_info)
         name_id = session_info["name_id"]
-        # make friendly to (JSON) serialization
-        #session_info['name_id'] = code(name_id)
-        name_id_coded = code(name_id)
-        issuer = session_info["issuer"]
-        del session_info["issuer"]
+        issuer = session_info.pop("issuer")
         self.cache.set(name_id, issuer, session_info,
                        session_info["not_on_or_after"])
-        session_info['name_id'] = name_id_coded
         return name_id
 
     def stale_sources_for_person(self, name_id, sources=None):


### PR DESCRIPTION
If we already promoted (in #0515de9f) the saml2.cache.Cache to be a bit smart when it
comes to understanding the data it stores - that is decoding name_id in the get() method,
let's be consistent and do the reverse operation directly in the set() method.

This also fixes the issue with djangosaml2 that PR #321 tried to solve (but ugly way).