### PR TITLE
Update SP config docs to reflect that default want_assertions_signed is False

### DIFF
--- a/doc/howto/config.rst
+++ b/doc/howto/config.rst
@@ -419,7 +419,7 @@ Indicates if this SP wants the IdP to send the assertions signed. This
 sets the WantAssertionsSigned attribute of the SPSSODescriptor node
 of the metadata so the IdP will know this SP preference.
 
-Valid values are True or False. Default value is True.
+Valid values are True or False. Default value is False.
 
 Example::
 


### PR DESCRIPTION
This addresses a pretty critical documentation misinformation. By default, the SP does *not* look at assertion signatures. It happily swallows unsigned assertions and responses. Also see https://github.com/rohe/pysaml2/blob/master/src/saml2/client_base.py#L114

When setting this to True the examples do not work anymore with the message:
```
Signature error: Signature missing for assertion
```
That's good!