### PR TITLE
Document sign_assertion and sign_reponse IdP config parameters

### DIFF
--- a/doc/howto/config.rst
+++ b/doc/howto/config.rst
@@ -270,6 +270,19 @@ idp/aa
 
 Directives that are specific to an IdP or AA service instance
 
+sign_assertion
+""""""""""""""
+
+Specifies if the IdP should sign the assertion in an authentication response
+or not. Can be True or False. Default is False.
+
+sign_response
+"""""""""""""
+
+Specifies if the IdP should sign the authentication response or not. Can be
+True or False. Default is False.
+
+
 policy
 """"""
 


### PR DESCRIPTION
It took me a while to understand that these parameters can easily be added to the IdP config. They're undocumented so far, but arguably pretty important :).