### PR TITLE
Fixes xmlsec output line parsing on CRLF platforms (e.g. Windows).

### DIFF
--- a/src/saml2/algsupport.py
+++ b/src/saml2/algsupport.py
@@ -42,7 +42,7 @@ def get_algorithm_support(xmlsec):
     pof.wait()
 
     if not p_err:
-        p = p_out.split('\n')
+        p = p_out.splitlines()
         algs = [x.strip('"') for x in p[1].split(',')]
         digest = []
         signing = []

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -586,7 +586,7 @@ def parse_xmlsec_output(output):
     :param output: The output from Popen
     :return: A boolean; True if the command was a success otherwise False
     """
-    for line in output.split("\n"):
+    for line in output.splitlines():
         if line == "OK":
             return True
         elif line == "FAIL":

--- a/tests/test_40_sigver.py
+++ b/tests/test_40_sigver.py
@@ -540,6 +540,19 @@ def test_sha256_signing():
     assert s
 
 
+def test_xmlsec_output_line_parsing():
+    output1 = "prefix\nOK\npostfix"
+    assert sigver.parse_xmlsec_output(output1)
+
+    output2 = "prefix\nFAIL\npostfix"
+    raises(sigver.XmlsecError, sigver.parse_xmlsec_output, output2)
+
+    output3 = "prefix\r\nOK\r\npostfix"
+    assert sigver.parse_xmlsec_output(output3)
+
+    output4 = "prefix\r\nFAIL\r\npostfix"
+    raises(sigver.XmlsecError, sigver.parse_xmlsec_output, output4)
+
 
 if __name__ == "__main__":
     # t = TestSecurity()


### PR DESCRIPTION
When executing xmlsec on Windows the output contains CRLF.  This caused sigver.parse_xmlsec_output() to not recognize successes.  This fix replaces str.split('\n') with str.splitlines() for cross-platform parsing.

Fixes #347 