### PR TITLE
Support session not on or after

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ tmp*
 *.tmpl
 *.iml
 _build/
+.cache
+*.swp
 
 example/idp3/htdocs/login.mako
 

--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -615,7 +615,7 @@ def _authn_context_decl_ref(decl_ref, authn_auth=None):
 
 def authn_statement(authn_class=None, authn_auth=None,
                     authn_decl=None, authn_decl_ref=None, authn_instant="",
-                    subject_locality=""):
+                    subject_locality="", session_not_on_or_after=None):
     """
     Construct the AuthnStatement
     :param authn_class: Authentication Context Class reference
@@ -639,6 +639,7 @@ def authn_statement(authn_class=None, authn_auth=None,
             saml.AuthnStatement,
             authn_instant=_instant,
             session_index=sid(),
+            session_not_on_or_after=session_not_on_or_after,
             authn_context=_authn_context_class_ref(
                 authn_class, authn_auth))
     elif authn_decl:
@@ -646,19 +647,22 @@ def authn_statement(authn_class=None, authn_auth=None,
             saml.AuthnStatement,
             authn_instant=_instant,
             session_index=sid(),
+            session_not_on_or_after=session_not_on_or_after,
             authn_context=_authn_context_decl(authn_decl, authn_auth))
     elif authn_decl_ref:
         res = factory(
             saml.AuthnStatement,
             authn_instant=_instant,
             session_index=sid(),
+            session_not_on_or_after=session_not_on_or_after,
             authn_context=_authn_context_decl_ref(authn_decl_ref,
                                                   authn_auth))
     else:
         res = factory(
             saml.AuthnStatement,
             authn_instant=_instant,
-            session_index=sid())
+            session_index=sid(),
+            session_not_on_or_after=session_not_on_or_after)
 
     if subject_locality:
         res.subject_locality = saml.SubjectLocality(text=subject_locality)
@@ -719,7 +723,7 @@ class Assertion(dict):
                   authn_class=None, authn_auth=None, authn_decl=None,
                   encrypt=None, sec_context=None, authn_decl_ref=None,
                   authn_instant="", subject_locality="", authn_statem=None,
-                  name_id=None):
+                  name_id=None, session_not_on_or_after=None):
         """ Construct the Assertion
 
         :param sp_entity_id: The entityid of the SP
@@ -770,7 +774,8 @@ class Assertion(dict):
             _authn_statement = authn_statement(authn_class, authn_auth,
                                                authn_decl, authn_decl_ref,
                                                authn_instant,
-                                               subject_locality)
+                                               subject_locality,
+                                               session_not_on_or_after=session_not_on_or_after)
         else:
             _authn_statement = None
 

--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -326,7 +326,8 @@ class Server(Entity):
 
     def setup_assertion(self, authn, sp_entity_id, in_response_to, consumer_url,
                         name_id, policy, _issuer, authn_statement, identity,
-                        best_effort, sign_response, farg=None, **kwargs):
+                        best_effort, sign_response, farg=None,
+                        session_not_on_or_after=None, **kwargs):
         """
         Construct and return the Assertion
 
@@ -370,17 +371,20 @@ class Server(Entity):
             assertion = ast.construct(
                 sp_entity_id, self.config.attribute_converters, policy,
                 issuer=_issuer, farg=farg['assertion'], name_id=name_id,
+                session_not_on_or_after=session_not_on_or_after,
                 **authn_args)
 
         elif authn_statement:  # Got a complete AuthnStatement
             assertion = ast.construct(
                 sp_entity_id, self.config.attribute_converters, policy,
                 issuer=_issuer, authn_statem=authn_statement,
-                farg=farg['assertion'], name_id=name_id, **kwargs)
+                farg=farg['assertion'], name_id=name_id,
+                **kwargs)
         else:
             assertion = ast.construct(
                 sp_entity_id, self.config.attribute_converters, policy,
                 issuer=_issuer, farg=farg['assertion'], name_id=name_id,
+                session_not_on_or_after=session_not_on_or_after,
                 **kwargs)
         return assertion
 
@@ -394,7 +398,7 @@ class Server(Entity):
                         encrypt_assertion_self_contained=False,
                         encrypted_advice_attributes=False,
                         pefim=False, sign_alg=None, digest_alg=None,
-                        farg=None):
+                        farg=None, session_not_on_or_after=None):
         """ Create a response. A layer of indirection.
 
         :param in_response_to: The session identifier of the request
@@ -455,7 +459,7 @@ class Server(Entity):
             assertion = self.setup_assertion(
                 authn, sp_entity_id, in_response_to, consumer_url, name_id,
                 policy, _issuer, authn_statement, [], True, sign_response,
-                farg=farg)
+                farg=farg, session_not_on_or_after=session_not_on_or_after)
             assertion.advice = saml.Advice()
 
             # assertion.advice.assertion_id_ref.append(saml.AssertionIDRef())
@@ -465,7 +469,8 @@ class Server(Entity):
             assertion = self.setup_assertion(
                 authn, sp_entity_id, in_response_to, consumer_url, name_id,
                 policy, _issuer, authn_statement, identity, True,
-                sign_response, farg=farg)
+                sign_response, farg=farg,
+                session_not_on_or_after=session_not_on_or_after)
 
         to_sign = []
         if not encrypt_assertion:
@@ -681,6 +686,7 @@ class Server(Entity):
                               encrypt_assertion_self_contained=True,
                               encrypted_advice_attributes=False, pefim=False,
                               sign_alg=None, digest_alg=None,
+                              session_not_on_or_after=None,
                               **kwargs):
         """ Constructs an AuthenticationResponse
 
@@ -741,11 +747,13 @@ class Server(Entity):
                     return self._authn_response(
                         in_response_to, destination, sp_entity_id, identity,
                         authn=_authn, issuer=issuer, pefim=pefim,
-                        sign_alg=sign_alg, digest_alg=digest_alg, **args)
+                        sign_alg=sign_alg, digest_alg=digest_alg,
+                        session_not_on_or_after=session_not_on_or_after, **args)
             return self._authn_response(
                 in_response_to, destination, sp_entity_id, identity,
                 authn=_authn, issuer=issuer, pefim=pefim, sign_alg=sign_alg,
-                digest_alg=digest_alg, **args)
+                digest_alg=digest_alg,
+                session_not_on_or_after=session_not_on_or_after, **args)
 
         except MissingValue as exc:
             return self.create_error_response(in_response_to, destination,
@@ -756,13 +764,15 @@ class Server(Entity):
                                       name_id_policy=None, userid=None,
                                       name_id=None, authn=None, authn_decl=None,
                                       issuer=None, sign_response=False,
-                                      sign_assertion=False, **kwargs):
+                                      sign_assertion=False,
+                                      session_not_on_or_after=None, **kwargs):
 
         return self.create_authn_response(identity, in_response_to, destination,
                                           sp_entity_id, name_id_policy, userid,
                                           name_id, authn, issuer,
                                           sign_response, sign_assertion,
-                                          authn_decl=authn_decl)
+                                          authn_decl=authn_decl,
+                                          session_not_on_or_after=session_not_on_or_after)
 
     # noinspection PyUnusedLocal
     def create_assertion_id_request_response(self, assertion_id, sign=False,


### PR DESCRIPTION
Hi,

The `samlp.AuthnResponse` class allows setting the `session_not_on_or_after` attribute. However, none of the methods that create an `AuthnResponse` actually allow passing this parameter in. So, this change adds `session_not_on_on_after` a parameter to all the ancestor methods of the method `authn_response`.

Please let me know if there's something that needs to be changed/improved.

Thanks!
Ashima