### PR TITLE
Fix crash on Python 3

### DIFF
--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -808,6 +808,6 @@ def sign_entity_descriptor(edesc, ident, secc, sign_alg=None, digest_alg=None):
 
     edesc.signature = pre_signature_part(ident, secc.my_cert, 1, sign_alg=sign_alg, digest_alg=digest_alg)
     edesc.id = ident
-    xmldoc = secc.sign_statement("%s" % edesc, class_name(edesc))
+    xmldoc = secc.sign_statement("%s" % edesc, class_name(edesc)).encode('utf-8')
     edesc = md.entity_descriptor_from_string(xmldoc)
     return edesc, xmldoc

--- a/src/saml2/metadata.py
+++ b/src/saml2/metadata.py
@@ -808,6 +808,6 @@ def sign_entity_descriptor(edesc, ident, secc, sign_alg=None, digest_alg=None):
 
     edesc.signature = pre_signature_part(ident, secc.my_cert, 1, sign_alg=sign_alg, digest_alg=digest_alg)
     edesc.id = ident
-    xmldoc = secc.sign_statement("%s" % edesc, class_name(edesc)).encode('utf-8')
+    xmldoc = secc.sign_statement("%s" % edesc, class_name(edesc))
     edesc = md.entity_descriptor_from_string(xmldoc)
     return edesc, xmldoc

--- a/src/saml2/sigver.py
+++ b/src/saml2/sigver.py
@@ -934,7 +934,7 @@ class CryptoBackendXmlSec1(CryptoBackend):
             # this doesn't work if --store-signatures are used
             if stdout == "":
                 if signed_statement:
-                    return signed_statement.decode('utf-8')
+                    return signed_statement
             logger.error(
                 "Signing operation failed :\nstdout : %s\nstderr : %s",
                 stdout, stderr)


### PR DESCRIPTION
I'm not sure if that's the best fix for the problem and it won't affect anything else.

Long story short - on Python 3, pysaml2 crashes if metadata is signed. `create_metadata_string` (and other methods) sign the string and expect a binary string as a response. But `CryptoBackendXmlSec1.sign_statement` forcibly decodes the binary string from xmlsec1 to a normal string.

On Python 2 it should not cause any problems as there's no distinction.