### PR TITLE
Fix bug in MetadataStore.extension().

### DIFF
--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -992,10 +992,7 @@ class MetadataStore(MetaData):
             try:
                 srvs = _md[entity_id][typ]
             except KeyError:
-                return None
-
-            if not srvs:
-                return srvs
+                continue
 
             res = []
             for srv in srvs:
@@ -1004,6 +1001,8 @@ class MetadataStore(MetaData):
                         if elem["__class__"] == service:
                             res.append(elem)
             return res
+
+        return None
 
     def ext_service(self, entity_id, typ, service, binding=None):
         known_entity = False

--- a/tests/test_30_mdstore.py
+++ b/tests/test_30_mdstore.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import re
+from collections import OrderedDict
 
 from future.backports.urllib.parse import quote_plus
 
@@ -454,6 +455,17 @@ def test_metadata_extension_algsupport():
     mds.imp(METADATACONF["12"])
     mdf = mds.metadata[full_path("uu.xml")]
     assert mds
+
+
+def test_extension():
+    mds = MetadataStore(ATTRCONV, None)
+    # use ordered dict to force expected entity to be last
+    metadata = OrderedDict()
+    metadata["1"] = {"entity1": {}}
+    metadata["2"] = {"entity2": {"idpsso_descriptor": [{"extensions": {"extension_elements": [{"__class__": "test"}]}}]}}
+    mds.metadata = metadata
+    assert mds.extension("entity2", "idpsso_descriptor", "test")
+
 
 if __name__ == "__main__":
     test_metadata_extension_algsupport()


### PR DESCRIPTION
Continue with the next metadata source if the entity id or the expected
type (SP or IDP) SSO descriptor is not found in the current metadata
source instead of prematurely returning.