### PR TITLE
Use six instead of futures for PY3 compatibility.

### DIFF
--- a/example/idp2/idp.py
+++ b/example/idp2/idp.py
@@ -10,9 +10,9 @@ import time
 from hashlib import sha1
 from cherrypy import wsgiserver
 from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter
-from future.backports.http.cookies import SimpleCookie
-from future.backports.urllib.parse import parse_qs
-from future.utils import PY3
+
+from six.moves.urllib.parse import parse_qs
+from six.moves.http_cookies import SimpleCookie
 
 from saml2 import BINDING_HTTP_ARTIFACT
 from saml2 import BINDING_URI
@@ -852,12 +852,7 @@ class NIM(Service):
 def info_from_cookie(kaka):
     logger.debug("KAKA: %s", kaka)
     if kaka:
-        cookie_obj = SimpleCookie()
-        if PY3:
-            import builtins
-            cookie_obj.load(builtins.str(kaka))
-        else:
-            cookie_obj.load(str(kaka))
+        cookie_obj = SimpleCookie(kaka)
         morsel = cookie_obj.get("idpauthn", None)
         if morsel:
             try:

--- a/src/saml2/httputil.py
+++ b/src/saml2/httputil.py
@@ -5,9 +5,8 @@ import time
 import cgi
 import six
 
-from future.backports.http.cookies import SimpleCookie
-from future.backports.urllib.parse import quote
-from future.backports.urllib.parse import parse_qs
+from six.moves.urllib.parse import quote, parse_qs
+from six.moves.http_cookies import SimpleCookie
 
 from saml2 import BINDING_HTTP_ARTIFACT
 from saml2 import BINDING_HTTP_REDIRECT


### PR DESCRIPTION
Gets the idp2 example running on Python 3.4.