### PR TITLE
Handle list of attribute values and serialize them properly.

### DIFF
--- a/src/saml2/attribute_converter.py
+++ b/src/saml2/attribute_converter.py
@@ -8,7 +8,7 @@ from importlib import import_module
 
 from saml2.s_utils import factory
 from saml2.s_utils import do_ava
-from saml2 import saml
+from saml2 import saml, ExtensionElement, NAMESPACE
 from saml2 import extension_elements_to_elements
 from saml2 import SAMLError
 from saml2.saml import NAME_FORMAT_UNSPECIFIED, NAMEID_FORMAT_PERSISTENT, NameID
@@ -495,7 +495,12 @@ class AttributeConverter(object):
             if name:
                 if name == "urn:oid:1.3.6.1.4.1.5923.1.1.1.10":
                     # special case for eduPersonTargetedID
-                    attr_value = do_ava(NameID(format=NAMEID_FORMAT_PERSISTENT, text=value).to_string())
+                    attr_value = []
+                    for v in value:
+                        extension_element = ExtensionElement("NameID", NAMESPACE,
+                                                             attributes={'Format': NAMEID_FORMAT_PERSISTENT}, text=v)
+                        attrval = saml.AttributeValue(extension_elements=[extension_element])
+                        attr_value.append(attrval)
                 else:
                     attr_value = do_ava(value)
                 attributes.append(factory(saml.Attribute,

--- a/tests/test_19_attribute_converter.py
+++ b/tests/test_19_attribute_converter.py
@@ -211,11 +211,12 @@ class TestAC():
         assert attr_conv._fro is None and attr_conv._to is None
 
     def test_from_local_nest_eduPersonTargetedID_in_NameID(self):
-        ava = {"edupersontargetedid": "test value"}
+        ava = {"edupersontargetedid": ["test value1", "test value2"]}
         attributes = from_local(self.acs, ava, URI_NF)
         assert len(attributes) == 1
-        assert len(attributes[0].attribute_value) == 1
-        assert attributes[0].attribute_value[0].text == NameID(format=NAMEID_FORMAT_PERSISTENT, text="test value").to_string().decode("utf-8")
+        assert len(attributes[0].attribute_value) == 2
+        assert attributes[0].attribute_value[0].extension_elements[0].text == "test value1"
+        assert attributes[0].attribute_value[1].extension_elements[0].text == "test value2"
 
 
 def test_noop_attribute_conversion():


### PR DESCRIPTION
A NameID can't be serialized directly as text since that is escaped when
producing the final XML output. Instead we wrap it in an
ExtensionElement, which is handled correctly.