### PR TITLE
Do not overwrite cache

### DIFF
--- a/src/saml2/cache.py
+++ b/src/saml2/cache.py
@@ -96,6 +96,7 @@ class Cache(object):
         """
         cni = code(name_id)
         (timestamp, info) = self._db[cni][entity_id]
+        info = info.copy()
         if check_not_on_or_after and time_util.after(timestamp):
             raise ToOld("past %s" % str(timestamp))
 


### PR DESCRIPTION
I haven't looked in-depth into the code, but It seems odd to me to overwrite the self._db cache with the decoded value, so instead return the copy of it.

I found this while fixing the unit tests of djangosaml2 where the session tried to json serialize a NameID object but couldn't.