### PR TITLE
The ID of each Signature element must be unique

### DIFF
--- a/src/saml2/server.py
+++ b/src/saml2/server.py
@@ -476,7 +476,7 @@ class Server(Entity):
         if not encrypt_assertion:
             if sign_assertion:
                 assertion.signature = pre_signature_part(assertion.id,
-                                                         self.sec.my_cert, 1,
+                                                         self.sec.my_cert, 2,
                                                          sign_alg=sign_alg,
                                                          digest_alg=digest_alg)
                 to_sign.append((class_name(assertion), assertion.id))


### PR DESCRIPTION
If the assertion and response both are signed, both Signatures have an
ID of `Signature1`. This creates invalid xml as xs:ID must be unique.
This fixes the issue when integrating with onelogin's python3-saml
client:
Element '{http://www.w3.org/2000/09/xmldsig#}Signature', attribute 'Id':
'Signature1' is not a valid value of the atomic type 'xs:ID'.