### PR TITLE
Add a namespace for AttributeValue xsi:type value

### DIFF
--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -166,7 +166,9 @@ class AttributeValueBase(SamlBase):
 
         try:
             self.extension_attributes[XSI_TYPE] = typ
+            self.extension_attributes['xmlns:xs'] = XS_NAMESPACE
         except AttributeError:
+            self._extatt['xmlns:xs'] = XS_NAMESPACE
             self._extatt[XSI_TYPE] = typ
 
     def get_type(self):

--- a/src/saml2/saml.py
+++ b/src/saml2/saml.py
@@ -166,10 +166,15 @@ class AttributeValueBase(SamlBase):
 
         try:
             self.extension_attributes[XSI_TYPE] = typ
-            self.extension_attributes['xmlns:xs'] = XS_NAMESPACE
         except AttributeError:
-            self._extatt['xmlns:xs'] = XS_NAMESPACE
             self._extatt[XSI_TYPE] = typ
+
+        if typ.startswith('xs:'):
+            try:
+                self.extension_attributes['xmlns:xs'] = XS_NAMESPACE
+            except AttributeError:
+                self._extatt['xmlns:xs'] = XS_NAMESPACE
+
 
     def get_type(self):
         try:


### PR DESCRIPTION
This fixes the issue when integrating with onelogin's python3-saml
client:
Element '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue',
attribute '{http://www.w3.org/2001/XMLSchema-instance}type': The QName
value 'xs:string' has no corresponding namespace declaration in
scope.