### PR TITLE
example/sp-wsgi/sp.py: respond with bytes (enhance WSGI compliance)

### DIFF
--- a/example/sp-wsgi/sp.py
+++ b/example/sp-wsgi/sp.py
@@ -106,21 +106,21 @@ def handle_static(environ, start_response, path):
     :return: wsgi response for the static file.
     """
     try:
-        text = open(path).read()
+        data = open(path, 'rb').read()
         if path.endswith(".ico"):
-            resp = Response(text, headers=[('Content-Type', "image/x-icon")])
+            resp = Response(data, headers=[('Content-Type', "image/x-icon")])
         elif path.endswith(".html"):
-            resp = Response(text, headers=[('Content-Type', 'text/html')])
+            resp = Response(data, headers=[('Content-Type', 'text/html')])
         elif path.endswith(".txt"):
-            resp = Response(text, headers=[('Content-Type', 'text/plain')])
+            resp = Response(data, headers=[('Content-Type', 'text/plain')])
         elif path.endswith(".css"):
-            resp = Response(text, headers=[('Content-Type', 'text/css')])
+            resp = Response(data, headers=[('Content-Type', 'text/css')])
         elif path.endswith(".js"):
-            resp = Response(text, headers=[('Content-Type', 'text/javascript')])
+            resp = Response(data, headers=[('Content-Type', 'text/javascript')])
         elif path.endswith(".png"):
-            resp = Response(text, headers=[('Content-Type', 'image/png')])
+            resp = Response(data, headers=[('Content-Type', 'image/png')])
         else:
-            resp = Response(text)
+            resp = Response(data)
     except IOError:
         resp = NotFound()
     return resp(environ, start_response)

--- a/src/saml2/httputil.py
+++ b/src/saml2/httputil.py
@@ -62,6 +62,9 @@ class Response(object):
             return [mte.render(**argv)]
         else:
             if isinstance(message, six.string_types):
+                # Note(JP): A WSGI app should always respond
+                # with bytes, so at this point the message should
+                # become encoded instead of passing a text object.
                 return [message]
             elif isinstance(message, six.binary_type):
                 return [message]


### PR DESCRIPTION
This addresses https://github.com/rohe/pysaml2/issues/368. Specifically, this just makes the static file handler in example/sp-wsgi/sp.py emit bytes. 

It looks like the `Response` class in src/saml2/httputil.py may still pass unicode objects to the WSGI layer, which is not WSGI-compliant.
