### PR TITLE
Update README with instructions for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ tmp*
 _build/
 .cache
 *.swp
+.tox
+env
 
 example/idp3/htdocs/login.mako
 
@@ -191,8 +193,6 @@ example/idp2/old_idp.xml
 example/sp-repoze/old_sp.xml
 
 example/sp-repoze/sp_conf_2.Pygmalion
-
-.gitignore.swp
 
 example/sp-repoze/sp_conf_2.py
 

--- a/README.rst
+++ b/README.rst
@@ -26,3 +26,15 @@ necessary pieces for building a SAML2 service provider or an identity provider.
 The distribution contains examples of both.
 Originally written to work in a WSGI environment there are extensions that
 allow you to use it with other frameworks.
+
+Testing
+=======
+PySAML2 uses the `pytest <http://doc.pytest.org/en/latest/>`_ framework for
+testing. To run the tests on your system's version of python 
+
+1. Create and activate a `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
+2. Inside the virtualenv, install the dependencies needed for testing :code:`pip install -r tests/test_requirements.txt`
+3. Run the tests :code:`py.test tests`
+
+To run tests in multiple python environments, you can use
+`pyenv <https://github.com/yyuu/pyenv>`_ with `tox <https://tox.readthedocs.io/en/latest/>`_.

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,4 @@
+mock==2.0.0
 pymongo==3.0.1
+pytest==3.0.3
 responses==0.5.0
-mock

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,5 @@
 envlist = py27,py34
 
 [testenv]
-deps = pytest
-       -rtests/test_requirements.txt
+deps = -rtests/test_requirements.txt
 commands = py.test tests/


### PR DESCRIPTION
The instructions in the file `doc/install.rst` do not work out-of-the-box. This PR adds explicit instructions to encourage new contributors to create test cases for their PRs and the project in general.

It also consolidates all testing dependencies into the `test_requirements.txt` file so that pytest does not need to be installed separately.