### PR TITLE
Use importlib in place of backports.test.support

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
+
 import copy
-import sys
-import os
-import re
+import importlib
 import logging
 import logging.handlers
-import six
+import os
+import re
+import sys
 
-from future.backports.test.support import import_module
+import six
 
 from saml2 import root_logger, BINDING_URI, SAMLError
 from saml2 import BINDING_SOAP
@@ -359,7 +360,7 @@ class Config(object):
         else:
             sys.path.insert(0, head)
 
-        return import_module(tail)
+        return importlib.import_module(tail)
 
     def load_file(self, config_file, metadata_construction=False):
         if config_file.endswith(".py"):

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 import hashlib
+import importlib
+import json
 import logging
 import os
 import sys
-import json
-import requests
-import six
 
 from hashlib import sha1
 from os.path import isfile
 from os.path import join
 
-from future.backports.test.support import import_module
+import requests
+import six
 
 from saml2 import md
 from saml2 import saml
@@ -694,7 +694,7 @@ class MetaDataLoader(MetaDataFile):
         i = func.rfind('.')
         module, attr = func[:i], func[i + 1:]
         try:
-            mod = import_module(module)
+            mod = importlib.import_module(module)
         except Exception as e:
             raise RuntimeError(
                 'Cannot find metadata provider function %s: "%s"' % (func, e))

--- a/src/saml2/mdstore.py
+++ b/src/saml2/mdstore.py
@@ -930,7 +930,7 @@ class MetadataStore(MetaData):
                     raise SAMLError("Misconfiguration in metadata %s" % item)
                 mod, clas = key.rsplit('.', 1)
                 try:
-                    mod = import_module(mod)
+                    mod = importlib.import_module(mod)
                     MDloader = getattr(mod, clas)
                 except (ImportError, AttributeError):
                     raise SAMLError("Unknown metadata loader %s" % key)

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -1,33 +1,22 @@
 #!/usr/bin/env python
+
+import base64
+import hashlib
+import hmac
 import logging
 import random
-
-import time
-import base64
-import six
 import sys
-import hmac
-import string
-
-# from python 2.5
-import imp
+import time
 import traceback
+import zlib
 
-if sys.version_info >= (2, 5):
-    import hashlib
-else:  # before python 2.5
-    import sha
+import six
 
 from saml2 import saml
 from saml2 import samlp
 from saml2 import VERSION
 from saml2.time_util import instant
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
-import zlib
 
 logger = logging.getLogger(__name__)
 
@@ -405,67 +394,6 @@ def verify_signature(secret, parts):
         return True
     else:
         return False
-
-
-FTICKS_FORMAT = "F-TICKS/SWAMID/2.0%s#"
-
-
-def fticks_log(sp, logf, idp_entity_id, user_id, secret, assertion):
-    """
-    'F-TICKS/' federationIdentifier '/' version *('#' attribute '=' value) '#'
-    Allowed attributes:
-        TS	the login time stamp
-        RP	the relying party entityID
-        AP	the asserting party entityID (typcially the IdP)
-        PN	a sha256-hash of the local principal name and a unique key
-        AM	the authentication method URN
-
-    :param sp: Client instance
-    :param logf: The log function to use
-    :param idp_entity_id: IdP entity ID
-    :param user_id: The user identifier
-    :param secret: A salt to make the hash more secure
-    :param assertion: A SAML Assertion instance gotten from the IdP
-    """
-    csum = hmac.new(secret, digestmod=hashlib.sha1)
-    csum.update(user_id)
-    ac = assertion.AuthnStatement[0].AuthnContext[0]
-
-    info = {
-        "TS": time.time(),
-        "RP": sp.entity_id,
-        "AP": idp_entity_id,
-        "PN": csum.hexdigest(),
-        "AM": ac.AuthnContextClassRef.text
-    }
-    logf.info(FTICKS_FORMAT % "#".join(["%s=%s" % (a, v) for a, v in info]))
-
-
-def dynamic_importer(name, class_name=None):
-    """
-    Dynamically imports modules / classes
-    """
-    try:
-        fp, pathname, description = imp.find_module(name)
-    except ImportError:
-        print("unable to locate module: " + name)
-        return None, None
-
-    try:
-        package = imp.load_module(name, fp, pathname, description)
-    except Exception:
-        raise
-
-    if class_name:
-        try:
-            _class = imp.load_module("%s.%s" % (name, class_name), fp,
-                                     pathname, description)
-        except Exception:
-            raise
-
-        return package, _class
-    else:
-        return package, None
 
 
 def exception_trace(exc):

--- a/src/saml2/s_utils.py
+++ b/src/saml2/s_utils.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import logging
 import random
+import string
 import sys
 import time
 import traceback


### PR DESCRIPTION
Remove (undeclared dependency) usage of backports.test.support. This was
pulling in `unittest2` as a runtime dependency instead of a test
dependency. It's also really not needed, as the functionality that it
provides was not being called. Just use importlib instead.

Remove unused functions in s_utils.py & alphabetize imports. Order according to: Python core, 3rd party, local pacakge.