### PR TITLE
Swap pycrypto* for pyca/cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'paste',
     'zope.interface',
     'repoze.who',
-    'pycryptodomex',
+    'cryptography',
     'pytz',
     'pyOpenSSL',
     'python-dateutil',

--- a/src/saml2/cert.py
+++ b/src/saml2/cert.py
@@ -8,7 +8,11 @@ import six
 from OpenSSL import crypto
 from os.path import join
 from os import remove
-from Cryptodome.Util import asn1
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.x509 import load_pem_x509_certificate
+
+backend = default_backend()
 
 class WrongInput(Exception):
     pass
@@ -194,9 +198,8 @@ class OpenSSLWrapper(object):
         f.close()
 
     def read_str_from_file(self, file, type="pem"):
-        f = open(file, 'rt')
-        str_data = f.read()
-        f.close()
+        with open(file, 'rb') as f:
+            str_data = f.read()
 
         if type == "pem":
             return str_data
@@ -336,31 +339,13 @@ class OpenSSLWrapper(object):
             cert_algorithm = cert.get_signature_algorithm()
             if six.PY3:
                 cert_algorithm = cert_algorithm.decode('ascii')
+                cert_str = cert_str.encode('ascii')
 
-            cert_asn1 = crypto.dump_certificate(crypto.FILETYPE_ASN1, cert)
-
-            der_seq = asn1.DerSequence()
-            der_seq.decode(cert_asn1)
-
-            cert_certificate = der_seq[0]
-            #cert_signature_algorithm=der_seq[1]
-            cert_signature = der_seq[2]
-
-            cert_signature_decoded = asn1.DerObject()
-            cert_signature_decoded.decode(cert_signature)
-
-            signature_payload = cert_signature_decoded.payload
-
-            sig_pay0 = signature_payload[0]
-            if ((isinstance(sig_pay0, int) and sig_pay0 != 0) or
-                (isinstance(sig_pay0, str) and sig_pay0 != '\x00')):
-                return (False,
-                       "The certificate should not contain any unused bits.")
-
-            signature = signature_payload[1:]
+            cert_crypto = load_pem_x509_certificate(cert_str, backend)
 
             try:
-                crypto.verify(ca_cert, signature, cert_certificate,
+                crypto.verify(ca_cert, cert_crypto.signature,
+                              cert_crypto.tbs_certificate_bytes,
                               cert_algorithm)
                 return True, "Signed certificate is valid and correctly signed by CA certificate."
             except crypto.Error as e:

--- a/src/saml2/entity.py
+++ b/src/saml2/entity.py
@@ -7,9 +7,6 @@ import six
 from binascii import hexlify
 from hashlib import sha1
 
-# from Crypto.PublicKey import RSA
-from Cryptodome.PublicKey import RSA
-
 from saml2.metadata import ENDPOINTS
 from saml2.profile import paos, ecp
 from saml2.soap import parse_soap_enveloped_saml_artifact_resolve


### PR DESCRIPTION
pyOpenSSL is already a dependency and pyOpenSSL uses cryptography.
This also reduces the complexity of the code significantly in several
places (and removes the need to directly manipulate asn1). A future
PR could remove pyOpenSSL entirely as all the cert behavior is supported
directly by cryptography.