### PR TITLE
Enable deployer to signal no name format in authn request

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -304,11 +304,20 @@ class Base(Entity):
                 if nameid_format is None:
                     nameid_format = self.config.getattr("name_id_format", "sp")
 
+                    # If no nameid_format has been set in the configuration
+                    # or passed in then transient is the default.
                     if nameid_format is None:
                         nameid_format = NAMEID_FORMAT_TRANSIENT
+
+                    # If a list has been configured or passed in choose the
+                    # first since NameIDPolicy can only have one format specified.
                     elif isinstance(nameid_format, list):
-                        # NameIDPolicy can only have one format specified
                         nameid_format = nameid_format[0]
+
+                    # Allow a deployer to signal that no format should be specified
+                    # in the NameIDPolicy by passing in or configuring the string 'None'.
+                    elif nameid_format == 'None':
+                        nameid_format = None
 
                 name_id_policy = samlp.NameIDPolicy(allow_create=allow_create,
                                                     format=nameid_format)


### PR DESCRIPTION
Enable a deployer to configure name_id_format with the string
'None' to signal that no Format attribute should be included
in the <NameIDPolicy> that is sent with the <AuthnRequest>. A
yaml null is still converted to a Python None that then results
in the default of Format being set to transient, so this patch
does not change default behavior.