### PR TITLE
Fix attribute filtering

### DIFF
--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -79,10 +79,15 @@ def filter_on_attributes(ava, required=None, optional=None, acs=None,
 
     def _match_attr_name(attr, ava):
         try:
-            friendly_name = attr["friendly_name"]
-        except KeyError:
-            friendly_name = get_local_name(acs, attr["name"],
+            friendly_name = get_local_name(acs, attr["name"], 
                                            attr["name_format"])
+        except:
+            friendly_name = None
+        if not friendly_name:
+            try:
+                friendly_name = attr["friendly_name"]
+            except KeyError:
+                pass
 
         _fn = _match(friendly_name, ava)
         if not _fn:  # In the unlikely case that someone has provided us with
@@ -90,6 +95,7 @@ def filter_on_attributes(ava, required=None, optional=None, acs=None,
             _fn = _match(attr["name"], ava)
 
         return _fn
+
 
     def _apply_attr_value_restrictions(attr, res, must=False):
         try:
@@ -105,7 +111,6 @@ def filter_on_attributes(ava, required=None, optional=None, acs=None,
         return _filter_values(ava[_fn], values, must)
 
     res = {}
-
     if required is None:
         required = []
 

--- a/src/saml2/assertion.py
+++ b/src/saml2/assertion.py
@@ -78,18 +78,15 @@ def filter_on_attributes(ava, required=None, optional=None, acs=None,
     """
 
     def _match_attr_name(attr, ava):
-        try:
-            friendly_name = get_local_name(acs, attr["name"], 
-                                           attr["name_format"])
-        except:
-            friendly_name = None
-        if not friendly_name:
+        
+        local_name = get_local_name(acs, attr["name"], attr["name_format"])
+        if not local_name:
             try:
-                friendly_name = attr["friendly_name"]
+                local_name = attr["friendly_name"]
             except KeyError:
                 pass
 
-        _fn = _match(friendly_name, ava)
+        _fn = _match(local_name, ava)
         if not _fn:  # In the unlikely case that someone has provided us with
             #  URIs as attribute names
             _fn = _match(attr["name"], ava)

--- a/tests/test_20_assertion.py
+++ b/tests/test_20_assertion.py
@@ -81,6 +81,18 @@ def test_filter_on_attributes_1():
     assert ava["serialNumber"] == ["12345"]
 
 
+def test_filter_on_attributes_2():
+    
+    a = to_dict(Attribute(friendly_name="surName",name="urn:oid:2.5.4.4",
+                          name_format=NAME_FORMAT_URI), ONTS)
+    required = [a]
+    ava = {"sn":["kakavas"]}
+
+    ava = filter_on_attributes(ava,required,acs=ac_factory())
+    assert list(ava.keys()) == ['sn']
+    assert ava["sn"] == ["kakavas"]
+
+
 def test_filter_on_attributes_without_friendly_name():
     ava = {"eduPersonTargetedID": "test@example.com",
            "eduPersonAffiliation": "test",
@@ -923,3 +935,4 @@ def test_assertion_with_authn_instant():
 
 if __name__ == "__main__":
     test_assertion_2()
+

--- a/tests/test_20_assertion.py
+++ b/tests/test_20_assertion.py
@@ -64,7 +64,7 @@ def test_filter_on_attributes_0():
     required = [a]
     ava = {"serialNumber": ["12345"]}
 
-    ava = filter_on_attributes(ava, required)
+    ava = filter_on_attributes(ava, required, acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert ava["serialNumber"] == ["12345"]
 
@@ -76,7 +76,7 @@ def test_filter_on_attributes_1():
     required = [a]
     ava = {"serialNumber": ["12345"], "givenName": ["Lars"]}
 
-    ava = filter_on_attributes(ava, required)
+    ava = filter_on_attributes(ava, required, acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert ava["serialNumber"] == ["12345"]
 
@@ -118,7 +118,7 @@ def test_filter_on_attributes_with_missing_required_attribute():
         name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10",
         name_format=NAME_FORMAT_URI), ONTS)
     with pytest.raises(MissingValue):
-        filter_on_attributes(ava, required=[eptid])
+        filter_on_attributes(ava, required=[eptid], acs=ac_factory())
 
 
 def test_filter_on_attributes_with_missing_optional_attribute():
@@ -127,7 +127,7 @@ def test_filter_on_attributes_with_missing_optional_attribute():
         friendly_name="eduPersonTargetedID",
         name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10",
         name_format=NAME_FORMAT_URI), ONTS)
-    assert filter_on_attributes(ava, optional=[eptid]) == {}
+    assert filter_on_attributes(ava, optional=[eptid], acs=ac_factory()) == {}
 
 
 # ----------------------------------------------------------------------
@@ -432,7 +432,7 @@ def test_filter_values_req_2():
     required = [a1, a2]
     ava = {"serialNumber": ["12345"], "givenName": ["Lars"]}
 
-    raises(MissingValue, filter_on_attributes, ava, required)
+    raises(MissingValue, filter_on_attributes, ava, required, acs=ac_factory())
 
 
 def test_filter_values_req_3():
@@ -444,7 +444,7 @@ def test_filter_values_req_3():
     required = [a]
     ava = {"serialNumber": ["12345"]}
 
-    ava = filter_on_attributes(ava, required)
+    ava = filter_on_attributes(ava, required, acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert ava["serialNumber"] == ["12345"]
 
@@ -458,7 +458,7 @@ def test_filter_values_req_4():
     required = [a]
     ava = {"serialNumber": ["12345"]}
 
-    raises(MissingValue, filter_on_attributes, ava, required)
+    raises(MissingValue, filter_on_attributes, ava, required, acs=ac_factory())
 
 
 def test_filter_values_req_5():
@@ -470,7 +470,7 @@ def test_filter_values_req_5():
     required = [a]
     ava = {"serialNumber": ["12345", "54321"]}
 
-    ava = filter_on_attributes(ava, required)
+    ava = filter_on_attributes(ava, required, acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert ava["serialNumber"] == ["12345"]
 
@@ -484,7 +484,7 @@ def test_filter_values_req_6():
     required = [a]
     ava = {"serialNumber": ["12345", "54321"]}
 
-    ava = filter_on_attributes(ava, required)
+    ava = filter_on_attributes(ava, required, acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert ava["serialNumber"] == ["54321"]
 
@@ -501,7 +501,7 @@ def test_filter_values_req_opt_0():
 
     ava = {"serialNumber": ["12345", "54321"]}
 
-    ava = filter_on_attributes(ava, [r], [o])
+    ava = filter_on_attributes(ava, [r], [o], acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert _eq(ava["serialNumber"], ["12345", "54321"])
 
@@ -519,7 +519,7 @@ def test_filter_values_req_opt_1():
 
     ava = {"serialNumber": ["12345", "54321"]}
 
-    ava = filter_on_attributes(ava, [r], [o])
+    ava = filter_on_attributes(ava, [r], [o], acs=ac_factory())
     assert list(ava.keys()) == ["serialNumber"]
     assert _eq(ava["serialNumber"], ["12345", "54321"])
 
@@ -555,7 +555,7 @@ def test_filter_values_req_opt_2():
     ava = {"surname": ["Hedberg"], "givenName": ["Roland"],
            "eduPersonAffiliation": ["staff"], "uid": ["rohe0002"]}
 
-    raises(MissingValue, "filter_on_attributes(ava, r, o)")
+    raises(MissingValue, "filter_on_attributes(ava, r, o, acs=ac_factory())")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_50_server.py
+++ b/tests/test_50_server.py
@@ -96,7 +96,7 @@ class TestServer1():
         self.client = client.Saml2Client(conf)
         self.name_id = self.server.ident.transient_nameid(
             "urn:mace:example.com:saml:roland:sp", "id12")
-        self.ava = {"givenName": ["Derek"], "surName": ["Jeter"],
+        self.ava = {"givenName": ["Derek"], "sn": ["Jeter"],
                "mail": ["derek@nyy.mlb.com"], "title": "The man"}
 
     def teardown_class(self):
@@ -110,7 +110,7 @@ class TestServer1():
 
         assert ava ==\
                {'mail': ['derek@nyy.mlb.com'], 'givenName': ['Derek'],
-                'surName': ['Jeter'], 'title': ['The man']}
+                'sn': ['Jeter'], 'title': ['The man']}
 
 
     def verify_encrypted_assertion(self, assertion, decr_text):
@@ -145,7 +145,7 @@ class TestServer1():
                                 format=saml.NAMEID_FORMAT_TRANSIENT)),
             attribute_statement=do_attribute_statement(
                 {
-                    ("", "", "surName"): ("Jeter", ""),
+                    ("", "", "sn"): ("Jeter", ""),
                     ("", "", "givenName"): ("Derek", ""),
                 }
             ),
@@ -164,12 +164,12 @@ class TestServer1():
         attr1 = attribute_statement.attribute[1]
         if attr0.attribute_value[0].text == "Derek":
             assert attr0.friendly_name == "givenName"
-            assert attr1.friendly_name == "surName"
+            assert attr1.friendly_name == "sn"
             assert attr1.attribute_value[0].text == "Jeter"
         else:
             assert attr1.friendly_name == "givenName"
             assert attr1.attribute_value[0].text == "Derek"
-            assert attr0.friendly_name == "surName"
+            assert attr0.friendly_name == "sn"
             assert attr0.attribute_value[0].text == "Jeter"
         # 
         subject = assertion.subject
@@ -187,7 +187,7 @@ class TestServer1():
                                 name_id=saml.NAMEID_FORMAT_TRANSIENT),
                 attribute_statement=do_attribute_statement(
                     {
-                        ("", "", "surName"): ("Jeter", ""),
+                        ("", "", "sn"): ("Jeter", ""),
                         ("", "", "givenName"): ("Derek", ""),
                     }
                 ),
@@ -277,7 +277,7 @@ class TestServer1():
         resp = self.server.create_authn_response(
             {
                 "eduPersonEntitlement": "Short stop",
-                "surName": "Jeter",
+                "sn": "Jeter",
                 "givenName": "Derek",
                 "mail": "derek.jeter@nyy.mlb.com",
                 "title": "The man"
@@ -394,7 +394,7 @@ class TestServer1():
         conf.load_file("server_conf")
         self.client = client.Saml2Client(conf)
 
-        ava = {"givenName": ["Derek"], "surName": ["Jeter"],
+        ava = {"givenName": ["Derek"], "sn": ["Jeter"],
                "mail": ["derek@nyy.mlb.com"], "title": "The man"}
 
         npolicy = samlp.NameIDPolicy(format=saml.NAMEID_FORMAT_TRANSIENT,
@@ -425,7 +425,7 @@ class TestServer1():
     def test_signed_response(self):
         name_id = self.server.ident.transient_nameid(
             "urn:mace:example.com:saml:roland:sp", "id12")
-        ava = {"givenName": ["Derek"], "surName": ["Jeter"],
+        ava = {"givenName": ["Derek"], "sn": ["Jeter"],
                "mail": ["derek@nyy.mlb.com"], "title": "The man"}
 
         signed_resp = self.server.create_authn_response(
@@ -1139,7 +1139,7 @@ class TestServer1():
             "not_on_or_after": soon,
             "user": {
                 "givenName": "Leo",
-                "surName": "Laport",
+                "sn": "Laport",
             }
         }
         self.client.users.add_information_about_person(sinfo)
@@ -1163,7 +1163,7 @@ class TestServer1():
             "not_on_or_after": soon,
             "user": {
                 "givenName": "Leo",
-                "surName": "Laport",
+                "sn": "Laport",
             }
         }
 
@@ -1188,7 +1188,7 @@ class TestServer1():
 #------------------------------------------------------------------------
 
 IDENTITY = {"eduPersonAffiliation": ["staff", "member"],
-            "surName": ["Jeter"], "givenName": ["Derek"],
+            "sn": ["Jeter"], "givenName": ["Derek"],
             "mail": ["foo@gmail.com"], "title": "The man"}
 
 
@@ -1234,7 +1234,7 @@ def _logout_request(conf_file):
         "not_on_or_after": soon,
         "user": {
             "givenName": "Leo",
-            "surName": "Laport",
+            "sn": "Laport",
         }
     }
     sp.users.add_information_about_person(sinfo)

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -366,7 +366,7 @@ class TestClient:
     def test_response_1(self):
         IDP = "urn:mace:example.com:saml:roland:idp"
 
-        ava = {"givenName": ["Derek"], "surName": ["Jeter"],
+        ava = {"givenName": ["Derek"], "sn": ["Jeter"],
                "mail": ["derek@nyy.mlb.com"], "title": ["The man"]}
 
         nameid_policy = samlp.NameIDPolicy(allow_create="false",
@@ -414,7 +414,7 @@ class TestClient:
 
         # --- authenticate another person
 
-        ava = {"givenName": ["Alfonson"], "surName": ["Soriano"],
+        ava = {"givenName": ["Alfonson"], "sn": ["Soriano"],
                "mail": ["alfonson@chc.mlb.com"], "title": ["outfielder"]}
 
         resp_str = "%s" % self.server.create_authn_response(
@@ -732,7 +732,7 @@ class TestClient:
 
     def setup_verify_authn_response(self):
         idp = "urn:mace:example.com:saml:roland:idp"
-        ava = {"givenName": ["Derek"], "surName": ["Jeter"],
+        ava = {"givenName": ["Derek"], "sn": ["Jeter"],
                "mail": ["derek@nyy.mlb.com"], "title": ["The man"]}
         ava_verify = {'mail': ['derek@nyy.mlb.com'], 'givenName': ['Derek'],
                       'sn': ['Jeter'], 'title': ["The man"]}
@@ -781,7 +781,7 @@ class TestClient:
                                 format=saml.NAMEID_FORMAT_TRANSIENT)),
             attribute_statement=do_attribute_statement(
                 {
-                    ("", "", "surName"): ("Jeter", ""),
+                    ("", "", "sn"): ("Jeter", ""),
                     ("", "", "givenName"): ("Derek", ""),
                 }
             ),
@@ -845,7 +845,7 @@ class TestClient:
         nameid_policy = samlp.NameIDPolicy(allow_create="false",
                                            format=saml.NAMEID_FORMAT_PERSISTENT)
 
-        asser = Assertion({"givenName": "Derek", "surName": "Jeter"})
+        asser = Assertion({"givenName": "Derek", "sn": "Jeter"})
         farg = add_path(
             {},
             ['assertion', 'subject', 'subject_confirmation', 'method',
@@ -916,7 +916,7 @@ class TestClient:
         nameid_policy = samlp.NameIDPolicy(allow_create="false",
                                            format=saml.NAMEID_FORMAT_PERSISTENT)
 
-        asser = Assertion({"givenName": "Derek", "surName": "Jeter"})
+        asser = Assertion({"givenName": "Derek", "sn": "Jeter"})
 
         subject_confirmation_specs = {
             'recipient': "http://lingon.catalogix.se:8087/",
@@ -1047,7 +1047,7 @@ class TestClient:
             name_id=name_id,
             farg=farg['assertion'])
 
-        asser_2 = Assertion({"surName": "Jeter"})
+        asser_2 = Assertion({"sn": "Jeter"})
 
         assertion_2 = asser_2.construct(
             self.client.config.entityid,
@@ -1333,7 +1333,7 @@ class TestClient:
             "not_on_or_after": in_a_while(minutes=15),
             "ava": {
                 "givenName": "Anders",
-                "surName": "Andersson",
+                "sn": "Andersson",
                 "mail": "anders.andersson@example.com"
             }
         }
@@ -1370,7 +1370,7 @@ class TestClient:
             "not_on_or_after": in_a_while(minutes=15),
             "ava": {
                 "givenName": "Anders",
-                "surName": "Andersson",
+                "sn": "Andersson",
                 "mail": "anders.andersson@example.com"
             },
             "session_index": SessionIndex("_foo")
@@ -1400,7 +1400,7 @@ class TestClient:
             "not_on_or_after": a_while_ago(minutes=15),
             "ava": {
                 "givenName": "Anders",
-                "surName": "Andersson",
+                "sn": "Andersson",
                 "mail": "anders.andersson@example.com"
             },
             "session_index": SessionIndex("_foo")
@@ -1493,7 +1493,7 @@ class TestClientWithDummy():
             "not_on_or_after": in_a_while(minutes=15),
             "ava": {
                 "givenName": "Anders",
-                "surName": "Andersson",
+                "sn": "Andersson",
                 "mail": "anders.andersson@example.com"
             }
         }


### PR DESCRIPTION
Use the internal representation names instead of metadata FriendlyNames for attributes in order to do name filtering. Solves #422 