### PR TITLE
Add config option to expose entityid as endpoint

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 __author__ = 'rolandh'
 
 
+ATTR_ENTITYID_ENDPOINT = "entityid_endpoint"
+
 COMMON_ARGS = [
     "entityid", "xmlsec_binary", "debug", "key_file", "cert_file",
     "encryption_keypairs", "additional_cert_files",
@@ -54,7 +56,8 @@ COMMON_ARGS = [
     "validate_certificate",
     "extensions",
     "allow_unknown_attributes",
-    "crypto_backend"
+    "crypto_backend",
+    ATTR_ENTITYID_ENDPOINT,
 ]
 
 SP_ARGS = [
@@ -510,6 +513,9 @@ class Config(object):
             for endp, binding in specs:
                 res[endp] = (service, binding)
         return res
+
+    def expose_entityid_endpoint(self):
+        return self.getattr(ATTR_ENTITYID_ENDPOINT, "")
 
 
 class SPConfig(Config):


### PR DESCRIPTION
This commit adds a new configuration option, namely `entityid_endpoint` as a common argument for frontends and backends. The configuration option is used to indicate whether the entityid should be used as an endpoint that returns the metadata xml document. It is expected that in such a case, the entityid is of URI format and represents a URL. 