### PR TITLE
Remove allow_unsolicited attribute from config object

### DIFF
--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -207,7 +207,6 @@ class Config(object):
         self.crypto_backend = 'xmlsec1'
         self.scope = ""
         self.allow_unknown_attributes = False
-        self.allow_unsolicited = False
         self.extension_schema = {}
         self.cert_handler_extra_class = None
         self.verify_encrypt_cert_advice = None


### PR DESCRIPTION
The `allow_unsolicited` attribute on the `Config` object is misleading. 

As this configuration option is available under the `services.sp` key, it should be accessed using `sp.config.getattr(<configuration-key>, <context>)` which in this case would be `sp.config.getattr('allow_unsolicited', 'sp')`.