### PR TITLE
Add force_authn sp configuration option

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -335,6 +335,14 @@ class Base(Entity):
         except KeyError:
             nsprefix = None
 
+        try:
+            force_authn = kwargs['force_authn']
+        except KeyError:
+            force_authn = self.config.getattr('force_authn', 'sp')
+        finally:
+            if force_authn:
+                args['force_authn'] = 'true'
+
         if kwargs:
             _args, extensions = self._filter_args(AuthnRequest(), extensions,
                                                   **kwargs)

--- a/src/saml2/config.py
+++ b/src/saml2/config.py
@@ -75,7 +75,8 @@ SP_ARGS = [
     "name_id_format",
     "name_id_format_allow_create",
     "logout_requests_signed",
-    "requested_attribute_name_format"
+    "requested_attribute_name_format",
+    "force_authn",
 ]
 
 AA_IDP_ARGS = [

--- a/tests/test_31_config.py
+++ b/tests/test_31_config.py
@@ -68,6 +68,7 @@ sp2 = {
             },
             "authn_requests_signed": True,
             "logout_requests_signed": True,
+            "force_authn": True,
         }
     },
     #"xmlsec_binary" : "/opt/local/bin/xmlsec1",
@@ -407,6 +408,16 @@ def test_crypto_backend():
     assert idpc.crypto_backend == 'XMLSecurity'
     sec = security_context(idpc)
     assert isinstance(sec.crypto, CryptoBackendXMLSecurity)
+
+def test_unset_force_authn():
+    cnf = SPConfig().load(sp1)
+    assert bool(cnf.getattr('force_authn', 'sp')) == False
+
+
+def test_set_force_authn():
+    cnf = SPConfig().load(sp2)
+    assert bool(cnf.getattr('force_authn', 'sp')) == True
+
 
 if __name__ == "__main__":
     test_crypto_backend()

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -280,6 +280,17 @@ class TestClient:
         assert nid_policy.allow_create == "false"
         assert nid_policy.format == saml.NAMEID_FORMAT_TRANSIENT
 
+    def test_create_auth_request_unset_force_authn(self):
+        req_id, req = self.client.create_authn_request(
+            "http://www.example.com/sso", sign=False, message_id="id1")
+        assert bool(req.force_authn) == False
+
+    def test_create_auth_request_set_force_authn(self):
+        req_id, req = self.client.create_authn_request(
+            "http://www.example.com/sso", sign=False, message_id="id1",
+            force_authn="true")
+        assert bool(req.force_authn) == True
+
     def test_create_auth_request_nameid_policy_allow_create(self):
         conf = config.SPConfig()
         conf.load_file("sp_conf_nameidpolicy")


### PR DESCRIPTION
Add `force_authn` configuration option. 

If the application defines `force_authn` as a keyword argument to `create_authn_request()` then it overrides the `force_authn` configuration option. Otherwise `force_authn` fallbacks to the configuration value. If the value is truthy, _"true"_ is given as the `ForceAuthn` value.