### PR TITLE
Allow testers to specify test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27,py34
 
 [testenv]
 deps = -rtests/test_requirements.txt
-commands = py.test tests/
+commands = py.test {posargs:tests/}


### PR DESCRIPTION
Until now the command `tox` would run all of the tests.
With this change one can specify a test to be run by running:

    tox -- path/to/test.py