### PR TITLE
Fix pytest warnings about deprecated pytest_funcarg__ prefix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,18 @@
 import os
+import pytest
 
 #TODO: On my system this function seems to be returning an incorrect location
-def pytest_funcarg__xmlsec(request):
+@pytest.fixture
+def xmlsec(request):
     for path in os.environ["PATH"].split(":"):
         fil = os.path.join(path, "xmlsec1")
         if os.access(fil,os.X_OK):
             return fil
 
     raise Exception("Can't find xmlsec1")
-    
-def pytest_funcarg__AVA(request):
+
+@pytest.fixture
+def AVA(request):
     return [
         {
             "surName": ["Jeter"],
@@ -27,4 +30,4 @@ def pytest_funcarg__AVA(request):
             "surName": ["Hedberg"],
             "givenName": ["Roland"],
         },
-    ]    
+    ]


### PR DESCRIPTION
When running tests, the following message appears:
```
WC1 None pytest_funcarg__AVA: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
```

As described, the prefix is replaced by the decorator.