### PR TITLE
Ensure signature checking for SAML Responses is enabled by default

### DIFF
--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -126,8 +126,8 @@ class Base(Entity):
             if v is False or v == 'false':
                 setattr(self, param, False)
 
-        if self.entity_type == "sp" and not any(self.want_assertions_signed,
-                                                self.want_response_signed):
+        if self.entity_type == "sp" and not any([self.want_assertions_signed,
+                                                self.want_response_signed]):
             logger.warning("The SAML service provider accepts unsigned SAML Responses " +
                            "and Assertions. This configuration is insecure.")
 

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -108,16 +108,23 @@ class Base(Entity):
         else:
             self.state = state_cache
 
+        # Handle values which are False by default
         self.logout_requests_signed = False
         self.allow_unsolicited = False
         self.authn_requests_signed = False
         self.want_assertions_signed = False
-        self.want_response_signed = True
-        for foo in ["allow_unsolicited", "authn_requests_signed",
-                    "logout_requests_signed", "want_assertions_signed"]:
-            v = self.config.getattr(foo, "sp")
+        for param in ["allow_unsolicited", "authn_requests_signed",
+                      "logout_requests_signed", "want_assertions_signed"]:
+            v = self.config.getattr(param, "sp")
             if v is True or v == 'true':
-                setattr(self, foo, True)
+                setattr(self, param, True)
+
+        # Handle values which are True by default
+        self.want_response_signed = True
+        for param in ["want_assertions_signed"]:
+            v = self.config.getattr(param, "sp")
+            if v is False or v == 'false':
+                setattr(self, param, False)
 
         self.artifact2response = {}
 

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -112,10 +112,9 @@ class Base(Entity):
         self.allow_unsolicited = False
         self.authn_requests_signed = False
         self.want_assertions_signed = False
-        self.want_response_signed = False
+        self.want_response_signed = True
         for foo in ["allow_unsolicited", "authn_requests_signed",
-                    "logout_requests_signed", "want_assertions_signed",
-                    "want_response_signed"]:
+                    "logout_requests_signed", "want_assertions_signed"]:
             v = self.config.getattr(foo, "sp")
             if v is True or v == 'true':
                 setattr(self, foo, True)

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -108,23 +108,25 @@ class Base(Entity):
         else:
             self.state = state_cache
 
-        # Handle values which are False by default
-        self.logout_requests_signed = False
-        self.allow_unsolicited = False
-        self.authn_requests_signed = False
-        self.want_assertions_signed = False
-        for param in ["allow_unsolicited", "authn_requests_signed",
-                      "logout_requests_signed", "want_assertions_signed"]:
-            v = self.config.getattr(param, "sp")
-            if v is True or v == 'true':
-                setattr(self, param, True)
+        attribute_defaults = {
+            "logout_requests_signed": False,
+            "allow_unsolicited": False,
+            "authn_requests_signed": False,
+            "want_assertions_signed": False,
+            "want_response_signed": True,
+        }
 
-        # Handle values which are True by default
-        self.want_response_signed = True
-        for param in ["want_assertions_signed"]:
-            v = self.config.getattr(param, "sp")
-            if v is False or v == 'false':
-                setattr(self, param, False)
+        for attr, val_default in attribute_defaults.items():
+            val_config = self.config.getattr(attr, "sp")
+            if val_config is None:
+                val = val_default
+            else:
+                val = val_config
+
+            if val == 'true':
+                val = True
+
+            setattr(self, attr, val)
 
         if self.entity_type == "sp" and not any([self.want_assertions_signed,
                                                 self.want_response_signed]):

--- a/src/saml2/client_base.py
+++ b/src/saml2/client_base.py
@@ -126,6 +126,11 @@ class Base(Entity):
             if v is False or v == 'false':
                 setattr(self, param, False)
 
+        if self.entity_type == "sp" and not any(self.want_assertions_signed,
+                                                self.want_response_signed):
+            logger.warning("The SAML service provider accepts unsigned SAML Responses " +
+                           "and Assertions. This configuration is insecure.")
+
         self.artifact2response = {}
 
     #

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -470,7 +470,7 @@ class AuthnResponse(StatusResponse):
             return_addrs=None, outstanding_queries=None,
             timeslack=0, asynchop=True, allow_unsolicited=False,
             test=False, allow_unknown_attributes=False,
-            want_assertions_signed=False, want_response_signed=True,
+            want_assertions_signed=False, want_response_signed=False,
             conv_info=None, **kwargs):
 
         StatusResponse.__init__(self, sec_context, return_addrs, timeslack,

--- a/src/saml2/response.py
+++ b/src/saml2/response.py
@@ -470,7 +470,7 @@ class AuthnResponse(StatusResponse):
             return_addrs=None, outstanding_queries=None,
             timeslack=0, asynchop=True, allow_unsolicited=False,
             test=False, allow_unknown_attributes=False,
-            want_assertions_signed=False, want_response_signed=False,
+            want_assertions_signed=False, want_response_signed=True,
             conv_info=None, **kwargs):
 
         StatusResponse.__init__(self, sec_context, return_addrs, timeslack,

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -389,6 +389,7 @@ class TestClient:
             destination="http://lingon.catalogix.se:8087/",
             sp_entity_id="urn:mace:example.com:saml:roland:sp",
             name_id_policy=nameid_policy,
+            sign_response=True,
             userid="foba0001@example.com",
             authn=AUTHN)
 
@@ -433,6 +434,7 @@ class TestClient:
             in_response_to="id2",
             destination="http://lingon.catalogix.se:8087/",
             sp_entity_id="urn:mace:example.com:saml:roland:sp",
+            sign_response=True,
             name_id_policy=nameid_policy,
             userid="also0001@example.com",
             authn=AUTHN)
@@ -889,7 +891,6 @@ class TestClient:
                                      node_id=assertion.id)
 
         sigass = rm_xmltag(sigass)
-
         response = sigver.response_factory(
             in_response_to="_012345",
             destination="http://lingon.catalogix.se:8087/",
@@ -912,6 +913,8 @@ class TestClient:
 
         resp_str = base64.encodestring(enctext.encode('utf-8'))
         # Now over to the client side
+        # Explicitely allow unsigned responses for this and the following 2 tests
+        self.client.want_response_signed = False
         resp = self.client.parse_authn_request_response(
             resp_str, BINDING_HTTP_POST,
             {"_012345": "http://foo.example.com/service"})
@@ -1313,6 +1316,9 @@ class TestClient:
 
     def test_signed_redirect(self):
 
+        # Revert configuration change to disallow unsinged responses
+        self.client.want_response_signed = True
+
         msg_str = "%s" % self.client.create_authn_request(
             "http://localhost:8088/sso", message_id="id1")[1]
 
@@ -1544,6 +1550,8 @@ class TestClientWithDummy():
         response = self.client.send(**http_args)
         print(response.text)
         _dic = unpack_form(response.text[3], "SAMLResponse")
+        # Explicitly allow unsigned responses for this test
+        self.client.want_response_signed = False
         resp = self.client.parse_authn_request_response(_dic["SAMLResponse"],
                                                         BINDING_HTTP_POST,
                                                         {sid: "/"})

--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -1549,7 +1549,7 @@ class TestClientWithDummy():
 
         response = self.client.send(**http_args)
         print(response.text)
-        _dic = unpack_form(response.text[3], "SAMLResponse")
+        _dic = unpack_form(response.text, "SAMLResponse")
         # Explicitly allow unsigned responses for this test
         self.client.want_response_signed = False
         resp = self.client.parse_authn_request_response(_dic["SAMLResponse"],

--- a/tests/test_60_sp.py
+++ b/tests/test_60_sp.py
@@ -46,6 +46,8 @@ AUTHN = {
 class TestSP():
     def setup_class(self):
         self.sp = make_plugin("rem", saml_conf="server_conf")
+        # Explicitly allow unsigned responses for this test
+        self.sp.saml_client.want_response_signed = False
         self.server = Server(config_file="idp_conf")
 
     def teardown_class(self):

--- a/tests/test_63_ecp.py
+++ b/tests/test_63_ecp.py
@@ -92,7 +92,7 @@ def test_complete_flow():
                                                 entity_id=sp_entity_id)
 
         resp = idp.create_ecp_authn_request_response(
-            destination, {"eduPersonEntitlement": "Short stop",
+            destination,{"eduPersonEntitlement": "Short stop",
                           "surName": "Jeter",
                           "givenName": "Derek",
                           "mail": "derek.jeter@nyy.mlb.com",
@@ -136,7 +136,8 @@ def test_complete_flow():
                 assert inst.text == "XYZ"
 
         # parse the response
-
+        # Explicitly allow unsigned responses for this test
+        sp.want_response_signed = False
         resp = sp.parse_authn_request_response(respdict["body"], None, {sid: "/"})
 
         print(resp.response)

--- a/tests/test_63_ecp.py
+++ b/tests/test_63_ecp.py
@@ -92,7 +92,7 @@ def test_complete_flow():
                                                 entity_id=sp_entity_id)
 
         resp = idp.create_ecp_authn_request_response(
-            destination,{"eduPersonEntitlement": "Short stop",
+            destination, {"eduPersonEntitlement": "Short stop",
                           "surName": "Jeter",
                           "givenName": "Derek",
                           "mail": "derek.jeter@nyy.mlb.com",

--- a/tests/test_65_authn_query.py
+++ b/tests/test_65_authn_query.py
@@ -92,6 +92,8 @@ def test_flow():
         # ------- @SP ----------
 
         xmlstr = get_msg(hinfo, binding)
+        # Explicitly allow unsigned responses for this test
+        sp.want_response_signed = False
         aresp = sp.parse_authn_request_response(xmlstr, binding,
                                                 {resp.in_response_to: "/"})
 

--- a/tests/test_68_assertion_id.py
+++ b/tests/test_68_assertion_id.py
@@ -78,7 +78,8 @@ def test_basic_flow():
         # --------- @SP -------------
 
         xmlstr = get_msg(hinfo, binding)
-
+        # Explicitly allow unsigned responses for this test
+        sp.want_response_signed = False
         aresp = sp.parse_authn_request_response(xmlstr, binding,
                                                 {resp.in_response_to: "/"})
 


### PR DESCRIPTION
Make sure that all Service Provider deployments based on pysaml2 are protected from SAML signature exclusion attacks by default. 
Fixes #424 