### PR TITLE
Fix for 459 HTTP_POST form nonconforming and shows submit

### DIFF
--- a/tests/test_51_client.py
+++ b/tests/test_51_client.py
@@ -1398,7 +1398,7 @@ class TestClient:
         binding, info = resp[entity_ids[0]]
         assert binding == BINDING_HTTP_POST
 
-        _dic = unpack_form(info["data"][3])
+        _dic = unpack_form(info["data"])
         res = self.server.parse_logout_request(_dic["SAMLRequest"],
                                                BINDING_HTTP_POST)
         assert b'<ns0:SessionIndex>_foo</ns0:SessionIndex>' in res.xmlstr
@@ -1428,7 +1428,7 @@ class TestClient:
         binding, info = resp[entity_ids[0]]
         assert binding == BINDING_HTTP_POST
 
-        _dic = unpack_form(info["data"][3])
+        _dic = unpack_form(info["data"])
         res = self.server.parse_logout_request(_dic["SAMLRequest"],
                                                BINDING_HTTP_POST)
         assert b'<ns0:SessionIndex>_foo</ns0:SessionIndex>' in res.xmlstr
@@ -1525,7 +1525,7 @@ class TestClientWithDummy():
         sid, http_args = self.client.prepare_for_authenticate(
             "urn:mace:example.com:saml:roland:idp", relay_state="really",
             binding=binding, response_binding=response_binding)
-        _dic = unpack_form(http_args["data"][3])
+        _dic = unpack_form(http_args["data"])
 
         req = self.server.parse_authn_request(_dic["SAMLRequest"], binding)
         resp_args = self.server.response_args(req.message, [response_binding])
@@ -1543,7 +1543,7 @@ class TestClientWithDummy():
 
         response = self.client.send(**http_args)
         print(response.text)
-        _dic = unpack_form(response.text[3], "SAMLResponse")
+        _dic = unpack_form(response.text, "SAMLResponse")
         resp = self.client.parse_authn_request_response(_dic["SAMLResponse"],
                                                         BINDING_HTTP_POST,
                                                         {sid: "/"})
@@ -1558,7 +1558,7 @@ class TestClientWithDummy():
         sid, auth_binding, http_args = self.client.prepare_for_negotiated_authenticate(
             "urn:mace:example.com:saml:roland:idp", relay_state="really",
             binding=binding, response_binding=response_binding)
-        _dic = unpack_form(http_args["data"][3])
+        _dic = unpack_form(http_args["data"])
 
         assert binding == auth_binding
 
@@ -1578,7 +1578,7 @@ class TestClientWithDummy():
 
         response = self.client.send(**http_args)
         print(response.text)
-        _dic = unpack_form(response.text[3], "SAMLResponse")
+        _dic = unpack_form(response.text, "SAMLResponse")
         resp = self.client.parse_authn_request_response(_dic["SAMLResponse"],
                                                         BINDING_HTTP_POST,
                                                         {sid: "/"})

--- a/tests/test_65_authn_query.py
+++ b/tests/test_65_authn_query.py
@@ -28,7 +28,7 @@ def get_msg(hinfo, binding):
     if binding == BINDING_SOAP:
         xmlstr = hinfo["data"]
     elif binding == BINDING_HTTP_POST:
-        _inp = hinfo["data"][3]
+        _inp = hinfo["data"]
         i = _inp.find(TAG1)
         i += len(TAG1) + 1
         j = _inp.find('"', i)

--- a/tests/test_68_assertion_id.py
+++ b/tests/test_68_assertion_id.py
@@ -27,7 +27,7 @@ def get_msg(hinfo, binding, response=False):
     if binding == BINDING_SOAP:
         msg = hinfo["data"]
     elif binding == BINDING_HTTP_POST:
-        _inp = hinfo["data"][3]
+        _inp = hinfo["data"]
         i = _inp.find(TAG1)
         i += len(TAG1) + 1
         j = _inp.find('"', i)


### PR DESCRIPTION
Fix for issue 459 "Form used with HTTP_POST binding nonconforming and
shows submit button". The fix introduces an HTML5 DOCTYPE declaration
and uses noscript tags appropriately to hide the submit button when
Javascript is enabled.

Modification of tests were necessary because the tests unecessarily
relied on the response being a list of strings with the <form> element
being the fourth item in the list, in order to unpack the form and pull
out the SAMLResponse and relay state for comparison. The new tests do not
require the response to be arbitrarily broken up as a list of
strings.