### PR TITLE
do_attribute_query passing wrong kwarg

### DIFF
--- a/src/saml2/client.py
+++ b/src/saml2/client.py
@@ -466,7 +466,7 @@ class Saml2Client(Base):
                                   attribute=attribute,
                                   sp_name_qualifier=sp_name_qualifier,
                                   name_qualifier=name_qualifier,
-                                  nameid_format=nameid_format,
+                                  format=nameid_format,
                                   response_args=response_args)
         elif binding == BINDING_HTTP_POST:
             mid = sid()


### PR DESCRIPTION
The function `do_attribute_query` needs to pass the `nameid_format` variable as a `kwarg` to function `create_attribute_query`. The correct key is `format`, not `nameid_format`.